### PR TITLE
[SM80] Backport mHC fused post + int8 all-reduce; fixes #28, #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ export NCCL_PROTO=Simple
 Tips:
 
 - `FULL_AND_PIECEWISE` (v0.6.x default recommendation, previously `PIECEWISE`) captures the whole decode step — attention, MoE dispatch, NCCL all-reduce and the DSpark draft loop — into one CUDA graph. Measured on 4x/8x A6000: single-stream decode 45.6 -> 67-70 tok/s (+47%); prefill is unchanged (compute-bound). Two prerequisites:
-  - Pin NCCL with `NCCL_ALGO=Ring NCCL_PROTO=Simple` (and prefer `--disable-custom-all-reduce`). Graph replay must re-issue the exact captured collective; NCCL's size-adaptive algorithm switching is what made FULL capture "crash on Ampere" — Ampere itself is fine.
-  - Bound `cudagraph_capture_sizes` as shown. FULL graphs keep private memory pools; capturing every batch size up to `--max-num-seqs` can cost >800 MB per GPU and OOM warmup at high `--gpu-memory-utilization`.
+    - Pin NCCL with `NCCL_ALGO=Ring NCCL_PROTO=Simple` (and prefer `--disable-custom-all-reduce` unless enabling `VLLM_MHC_AR_INT8`, which requires custom all-reduce). Graph replay must re-issue the exact captured collective; NCCL's size-adaptive algorithm switching is what made FULL capture "crash on Ampere" — Ampere itself is fine.
+    - Bound `cudagraph_capture_sizes` as shown. FULL graphs keep private memory pools; capturing every batch size up to `--max-num-seqs` can cost >800 MB per GPU and OOM warmup at high `--gpu-memory-utilization`.
 - Adjust your TP (--tensor-parallel-size) and PP (--pipeline-parallel-size) accordingly.
 - head dtype override helps reduce garbage outputs.
 - DSpark is not working very well if you have PP>1.
@@ -111,8 +111,9 @@ All knobs this fork has added over stock vLLM. Defaults are what the images ship
 
 | Variable | Meaning |
 | --- | --- |
-| `VLLM_MHC_PRENORM_SHARD` | Shard the mHC prenorm GEMM across TP ranks (pays off at TP8, hurts at TP4). |
-| `VLLM_MHC_POST_FUSE_SQRSUM` | Fold the mHC prenorm row-sqrsum into `mhc_post`. |
+| `VLLM_MHC_PRENORM_SHARD` | Shard the mHC prenorm GEMM across TP ranks (pays off at TP8, hurts at TP4). Requires `VLLM_MHC_POST_FUSE_SQRSUM=1`; startup fails if the shard is requested without it. |
+| `VLLM_MHC_POST_FUSE_SQRSUM` | Fold the mHC prenorm row-sqrsum into `mhc_post`; required by `VLLM_MHC_PRENORM_SHARD`. |
+| `VLLM_MHC_AR_INT8` | Transport prefill attention and MoE all-reduces as blockwise int8 and consume them directly in `mhc_post`. Requires custom all-reduce and a sufficiently large `VLLM_MAX_SIZE_MB_CUSTOM_ALL_REDUCE`; changes numerics. |
 | `VLLM_UNREPLICATE_ATTN_GEMMS` | De-duplicate attention GEMMs that are replicated across TP ranks. |
 | `VLLM_INDEXER_QUERY_SHARD` / `VLLM_INDEXER_QUERY_SHARD_QPATH` | Shard the sparse-indexer query projection across TP ranks. |
 | `VLLM_SPARSE_RAGGED_FAST_SCAN` | Faster ragged-index scan in sparse prefill. |

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -74,6 +74,121 @@ __global__ void __launch_bounds__(512, 1)
   }
 }
 
+constexpr int kQBlock = 32;
+
+struct __align__(16) QBlock {
+  int4 lo, hi;
+};
+
+template <int ngpus, bool ABSOLUTE = false>
+__global__ void __launch_bounds__(512, 1)
+    cross_device_reduce_2stage_int8(RankData* _dp, RankSignals sg,
+                                    Signal* self_sg,
+                                    int8_t* __restrict__ result,
+                                    nv_bfloat16* __restrict__ result_s,
+                                    int rank, int nblk, int64_t scale_off,
+                                    int64_t tmp_scale_off) {
+  int tid = blockIdx.x * blockDim.x + threadIdx.x;
+  int stride = gridDim.x * blockDim.x;
+  int part = nblk / ngpus;
+  int start = rank * part;
+  int end = rank == ngpus - 1 ? nblk : start + part;
+  int largest_part = part + nblk % ngpus;
+
+  const QBlock* qptr[ngpus];
+  const nv_bfloat16* sptr[ngpus];
+  QBlock* tmp_q[ngpus];
+  nv_bfloat16* tmp_s[ngpus];
+#pragma unroll
+  for (int i = 0; i < ngpus; i++) {
+    int target = ABSOLUTE ? i : (rank + i) % ngpus;
+    auto base = (const char*)_dp->ptrs[target];
+    qptr[i] = (const QBlock*)base;
+    sptr[i] = (const nv_bfloat16*)(base + scale_off);
+    auto t = (char*)get_tmp_buf<QBlock>(sg.signals[target]);
+    tmp_q[i] = (QBlock*)t;
+    tmp_s[i] = (nv_bfloat16*)(t + tmp_scale_off);
+  }
+  auto self_t = (char*)get_tmp_buf<QBlock>(sg.signals[rank]);
+  auto self_q = (QBlock*)self_t;
+  auto self_s = (nv_bfloat16*)(self_t + tmp_scale_off);
+  barrier_at_start<ngpus>(sg, self_sg, rank);
+
+  for (int idx = start + tid; idx < end; idx += stride) {
+    float acc[kQBlock];
+#pragma unroll
+    for (int j = 0; j < kQBlock; j++) acc[j] = 0.0f;
+#pragma unroll
+    for (int i = 0; i < ngpus; i++) {
+      QBlock v = qptr[i][idx];
+      float sc = __bfloat162float(sptr[i][idx]);
+      auto b = reinterpret_cast<const int8_t*>(&v);
+#pragma unroll
+      for (int j = 0; j < kQBlock; j++) acc[j] += float(b[j]) * sc;
+    }
+    float amax = 0.0f;
+#pragma unroll
+    for (int j = 0; j < kQBlock; j++) amax = fmaxf(amax, fabsf(acc[j]));
+    float inv = amax > 0.0f ? 127.0f / amax : 0.0f;
+    QBlock o;
+    auto ob = reinterpret_cast<int8_t*>(&o);
+#pragma unroll
+    for (int j = 0; j < kQBlock; j++) {
+      int q = __float2int_rn(acc[j] * inv);
+      ob[j] = (int8_t)min(max(q, -127), 127);
+    }
+    self_q[idx - start] = o;
+    self_s[idx - start] = __float2bfloat16(amax / 127.0f);
+  }
+  barrier_at_end<ngpus>(sg, self_sg, rank);
+
+  for (int idx = tid; idx < largest_part; idx += stride) {
+#pragma unroll
+    for (int i = 0; i < ngpus; i++) {
+      int gather_from_rank = ABSOLUTE ? i : ((rank + i) % ngpus);
+      if (gather_from_rank == ngpus - 1 || idx < part) {
+        int dst_idx = gather_from_rank * part + idx;
+        ((QBlock*)result)[dst_idx] = tmp_q[i][idx];
+        result_s[dst_idx] = tmp_s[i][idx];
+      }
+    }
+  }
+}
+
+static __global__ void __launch_bounds__(256)
+    quantize_blockwise_int8(const nv_bfloat16* __restrict__ inp,
+                            int8_t* __restrict__ out, int nblk,
+                            int64_t scale_off) {
+  auto out_s = (nv_bfloat16*)(out + scale_off);
+  for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < nblk;
+       idx += gridDim.x * blockDim.x) {
+    const int4* src = (const int4*)(inp + (int64_t)idx * kQBlock);
+    int4 v0 = src[0], v1 = src[1], v2 = src[2], v3 = src[3];
+    nv_bfloat16 raw[kQBlock];
+    reinterpret_cast<int4*>(raw)[0] = v0;
+    reinterpret_cast<int4*>(raw)[1] = v1;
+    reinterpret_cast<int4*>(raw)[2] = v2;
+    reinterpret_cast<int4*>(raw)[3] = v3;
+
+    float x[kQBlock], amax = 0.0f;
+#pragma unroll
+    for (int j = 0; j < kQBlock; j++) {
+      x[j] = __bfloat162float(raw[j]);
+      amax = fmaxf(amax, fabsf(x[j]));
+    }
+    float inv = amax > 0.0f ? 127.0f / amax : 0.0f;
+    QBlock o;
+    auto ob = reinterpret_cast<int8_t*>(&o);
+#pragma unroll
+    for (int j = 0; j < kQBlock; j++) {
+      int q = __float2int_rn(x[j] * inv);
+      ob[j] = (int8_t)min(max(q, -127), 127);
+    }
+    ((QBlock*)out)[idx] = o;
+    out_s[idx] = __float2bfloat16(amax / 127.0f);
+  }
+}
+
 using IPC_KEY = std::array<uint8_t, sizeof(cudaIpcMemHandle_t)>;
 static_assert(sizeof(IPC_KEY) == sizeof(cudaIpcMemHandle_t));
 static_assert(alignof(IPC_KEY) == alignof(cudaIpcMemHandle_t));
@@ -343,6 +458,75 @@ class CustomAllreduce {
     }
 #undef REDUCE_CASE
 #undef KL
+  }
+
+  void allreduce_int8(cudaStream_t stream, int8_t* input, int8_t* output,
+                      nv_bfloat16* output_scales, int nblk, int64_t scale_off,
+                      int64_t tmp_scale_off, int threads = 512,
+                      int block_limit = defaultBlockLimit) {
+    if (block_limit > kMaxBlocks)
+      throw std::runtime_error("max supported block limit is " +
+                               std::to_string(kMaxBlocks) + ". Got " +
+                               std::to_string(block_limit));
+    if (nblk % world_size_ != 0)
+      throw std::runtime_error(
+          "int8 custom allreduce requires the block count to be divisible by "
+          "the world size; got " +
+          std::to_string(nblk) + " blocks on " + std::to_string(world_size_) +
+          " ranks");
+
+    RankData* ptrs;
+    cudaStreamCaptureStatus status;
+    CUDACHECK(cudaStreamIsCapturing(stream, &status));
+    if (status == cudaStreamCaptureStatusActive) {
+      ptrs = d_rank_data_base_ + graph_unreg_buffers_.size();
+      graph_unreg_buffers_.push_back(input);
+    } else {
+      auto it = buffers_.find(input);
+      if (it == buffers_.end())
+        throw std::runtime_error(
+            "buffer address " +
+            std::to_string(reinterpret_cast<uint64_t>(input)) +
+            " is not registered!");
+      ptrs = it->second;
+    }
+    int blocks = std::min(block_limit, (nblk + threads - 1) / threads);
+
+    const char* abs_env = std::getenv("VLLM_AR_INT8_ABSOLUTE_ORDER");
+    bool absolute = abs_env != nullptr && std::strcmp(abs_env, "1") == 0;
+
+#define KL_INT8(ngpus)                                                \
+  if (absolute)                                                       \
+    cross_device_reduce_2stage_int8<ngpus, true>                      \
+        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, \
+                                         output_scales, rank_, nblk,  \
+                                         scale_off, tmp_scale_off);   \
+  else                                                                \
+    cross_device_reduce_2stage_int8<ngpus, false>                     \
+        <<<blocks, threads, 0, stream>>>(ptrs, sg_, self_sg_, output, \
+                                         output_scales, rank_, nblk,  \
+                                         scale_off, tmp_scale_off);
+
+    switch (world_size_) {
+      case 2:
+        KL_INT8(2);
+        break;
+      case 4:
+        KL_INT8(4);
+        break;
+      case 6:
+        KL_INT8(6);
+        break;
+      case 8:
+        KL_INT8(8);
+        break;
+      default:
+        throw std::runtime_error(
+            "custom allreduce only supports num gpus in (2,4,6,8). Actual num "
+            "gpus = " +
+            std::to_string(world_size_));
+    }
+#undef KL_INT8
   }
 
   void allgather(cudaStream_t stream, void* input, void* output, int size_bytes,

--- a/csrc/libtorch_stable/custom_all_reduce.cu
+++ b/csrc/libtorch_stable/custom_all_reduce.cu
@@ -115,6 +115,52 @@ void all_reduce(fptr_t _fa, torch::stable::Tensor& inp,
   }
 }
 
+void all_reduce_int8(fptr_t _fa, torch::stable::Tensor& inp,
+                     torch::stable::Tensor& out_q, torch::stable::Tensor& out_s,
+                     fptr_t _reg_buffer, int64_t reg_buffer_sz_bytes) {
+  auto fa = reinterpret_cast<vllm::CustomAllreduce*>(_fa);
+  const torch::stable::accelerator::DeviceGuard device_guard(
+      inp.get_device_index());
+  const cudaStream_t stream = get_current_cuda_stream(inp.get_device_index());
+
+  STD_TORCH_CHECK(inp.scalar_type() == torch::headeronly::ScalarType::BFloat16,
+                  "int8 custom allreduce takes a bf16 input");
+  STD_TORCH_CHECK(out_q.scalar_type() == torch::headeronly::ScalarType::Char);
+  STD_TORCH_CHECK(out_s.scalar_type() ==
+                  torch::headeronly::ScalarType::BFloat16);
+  STD_TORCH_CHECK(_is_weak_contiguous(inp));
+  STD_TORCH_CHECK(_is_weak_contiguous(out_q));
+  STD_TORCH_CHECK(_is_weak_contiguous(out_s));
+  STD_TORCH_CHECK(inp.numel() % vllm::kQBlock == 0,
+                  "payload must be a multiple of the 32-element block");
+  STD_TORCH_CHECK(inp.numel() == out_q.numel());
+
+  int64_t nblk = inp.numel() / vllm::kQBlock;
+  STD_TORCH_CHECK(out_s.numel() == nblk, "one scale per block");
+  int64_t scale_off = ((inp.numel() + 15) / 16) * 16;
+  STD_TORCH_CHECK(scale_off + nblk * 2 <= reg_buffer_sz_bytes,
+                  "registered buffer too small for the int8+scale payload");
+
+  auto reg_buffer = reinterpret_cast<int8_t*>(_reg_buffer);
+  STD_TORCH_CHECK(reg_buffer != nullptr,
+                  "int8 custom allreduce requires a registered buffer");
+
+  int64_t threads = 256;
+  int64_t blocks = std::min<int64_t>(1024, (nblk + threads - 1) / threads);
+  vllm::quantize_blockwise_int8<<<blocks, threads, 0, stream>>>(
+      reinterpret_cast<const nv_bfloat16*>(inp.const_data_ptr()), reg_buffer,
+      nblk, scale_off);
+
+  int64_t part = nblk / fa->world_size_;
+  int64_t largest_part = part + nblk % fa->world_size_;
+  int64_t tmp_scale_off = ((largest_part * vllm::kQBlock + 15) / 16) * 16;
+
+  fa->allreduce_int8(stream, reg_buffer,
+                     reinterpret_cast<int8_t*>(out_q.mutable_data_ptr()),
+                     reinterpret_cast<nv_bfloat16*>(out_s.mutable_data_ptr()),
+                     nblk, scale_off, tmp_scale_off);
+}
+
 void dispose(fptr_t _fa) {
   delete reinterpret_cast<vllm::CustomAllreduce*>(_fa);
 }

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -459,6 +459,9 @@ fptr_t init_custom_ar(const std::vector<int64_t>& fake_ipc_ptrs,
 void all_reduce(fptr_t _fa, torch::stable::Tensor& inp,
                 torch::stable::Tensor& out, fptr_t reg_buffer,
                 int64_t reg_buffer_sz_bytes);
+void all_reduce_int8(fptr_t _fa, torch::stable::Tensor& inp,
+                     torch::stable::Tensor& out_q, torch::stable::Tensor& out_s,
+                     fptr_t reg_buffer, int64_t reg_buffer_sz_bytes);
 void custom_all_gather(fptr_t _fa, torch::stable::Tensor& inp,
                        torch::stable::Tensor& out, fptr_t reg_buffer,
                        int64_t reg_buffer_sz_bytes);

--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -975,6 +975,9 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C_custom_ar, custom_ar) {
   custom_ar.def(
       "all_reduce(int fa, Tensor inp, Tensor! out, int reg_buffer, "
       "int reg_buffer_sz_bytes) -> ()");
+  custom_ar.def(
+      "all_reduce_int8(int fa, Tensor inp, Tensor! out_q, Tensor! out_s, "
+      "int reg_buffer, int reg_buffer_sz_bytes) -> ()");
   custom_ar.def("dispose(int fa) -> ()");
   custom_ar.def("meta_size() -> int");
   custom_ar.def("register_buffer(int fa, int[] ipc_tensors) -> ()");
@@ -989,6 +992,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C_custom_ar, custom_ar) {
 STABLE_TORCH_LIBRARY_IMPL(_C_custom_ar, CUDA, custom_ar) {
   custom_ar.impl("init_custom_ar", TORCH_BOX(&init_custom_ar));
   custom_ar.impl("all_reduce", TORCH_BOX(&all_reduce));
+  custom_ar.impl("all_reduce_int8", TORCH_BOX(&all_reduce_int8));
 }
 
 STABLE_TORCH_LIBRARY_IMPL(_C_custom_ar, CPU, custom_ar) {

--- a/tests/distributed/test_custom_all_reduce_large.py
+++ b/tests/distributed/test_custom_all_reduce_large.py
@@ -67,6 +67,20 @@ def _worker() -> int:
     torch.manual_seed(1234)
     payload = (torch.randn(rows, HIDDEN, device="cuda") * (rank + 1)).to(DTYPE)
 
+    if os.environ.get("RUN_INT8") == "1":
+        from vllm.model_executor.kernels.mhc.ar_int8 import int8_all_reduce
+
+        ref = payload.float()
+        dist.all_reduce(ref)
+        out_q, out_s = int8_all_reduce(payload)
+        got = out_q.float() * out_s.float().repeat_interleave(32, dim=-1)
+        torch.accelerator.synchronize()
+        rel = (got - ref).abs().max().item() / ref.abs().max().item()
+        ok = rel < 5e-2
+        if rank == 0:
+            print(f"int8_ar rel_err={rel:.3e} -> {'PASS' if ok else 'FAIL'}")
+        return 0 if ok else 1
+
     ca = get_tp_group().device_communicator.ca_comm
     took_custom = ca is not None and ca.should_custom_ar(payload)
     if took_custom != expect_custom:
@@ -108,6 +122,30 @@ def test_large_payload_all_reduce(knob_mb: int | None):
         env.pop("VLLM_MAX_SIZE_MB_CUSTOM_ALL_REDUCE", None)
     else:
         env["VLLM_MAX_SIZE_MB_CUSTOM_ALL_REDUCE"] = str(knob_mb)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--nproc_per_node=8",
+            os.path.abspath(__file__),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=900,
+    )
+    assert result.returncode == 0, result.stdout[-4000:] + result.stderr[-4000:]
+
+
+@pytest.mark.skipif(
+    current_platform.device_count() < 8,
+    reason="compressed prefill all-reduce needs the full 8-rank TP group",
+)
+def test_int8_payload_all_reduce():
+    env = dict(os.environ)
+    env["RUN_INT8"] = "1"
+    env["VLLM_MAX_SIZE_MB_CUSTOM_ALL_REDUCE"] = "32"
     result = subprocess.run(
         [
             sys.executable,

--- a/tests/kernels/test_mhc_kernels.py
+++ b/tests/kernels/test_mhc_kernels.py
@@ -364,6 +364,176 @@ def test_mhc_post_tilelang(num_tokens, hidden_size, hc_mult):
     torch.testing.assert_close(out, ref, atol=5e-2, rtol=1e-2)
 
 
+def test_prenorm_shard_requires_sqrsum_fold(monkeypatch):
+    from vllm.model_executor.kernels.mhc import tilelang as tilelang_mod
+
+    tilelang_mod._fuse_sqrsum_enabled.cache_clear()
+    monkeypatch.setattr(tilelang_mod.envs, "VLLM_MHC_PRENORM_SHARD", True)
+    monkeypatch.setattr(tilelang_mod.envs, "VLLM_MHC_POST_FUSE_SQRSUM", False)
+
+    with pytest.raises(ValueError, match="VLLM_MHC_POST_FUSE_SQRSUM=1"):
+        tilelang_mod.validate_mhc_optimization_flags()
+
+    tilelang_mod._fuse_sqrsum_enabled.cache_clear()
+
+
+@pytest.mark.parametrize("sqrsum_ready", [False, True])
+def test_prenorm_router_skips_a_completed_sqrsum(monkeypatch, sqrsum_ready):
+    import importlib
+
+    from vllm.model_executor.kernels.mhc import tilelang as tilelang_mod
+
+    triton_mod = importlib.import_module("vllm.model_executor.kernels.mhc.triton")
+    seen = []
+    monkeypatch.setattr(
+        triton_mod,
+        "hc_prenorm_gemm_cublas",
+        lambda x, fn, out, sqrsum: seen.append(sqrsum),
+    )
+    hidden, hc_mult, num_tokens = 4096, 4, 64
+    k = hidden * hc_mult
+    x = torch.zeros(num_tokens, k, dtype=torch.bfloat16)
+    fn = torch.zeros(24, k, dtype=torch.float32)
+    out = torch.zeros(1, num_tokens, 24, dtype=torch.float32)
+    sqrsum = torch.zeros(1, num_tokens, dtype=torch.float32)
+
+    tilelang_mod._tilelang_hc_prenorm_gemm(
+        x,
+        fn,
+        out,
+        sqrsum,
+        hidden,
+        hc_mult,
+        sqrsum_ready=sqrsum_ready,
+    )
+    assert len(seen) == 1
+    assert seen[0] is (None if sqrsum_ready else sqrsum)
+
+
+def test_int8_all_reduce_requires_custom_all_reduce(monkeypatch):
+    from types import SimpleNamespace
+
+    import vllm.distributed.parallel_state as parallel_state
+    from vllm.model_executor.kernels.mhc.ar_int8 import assert_hoist_preconditions
+
+    tp_group = SimpleNamespace(
+        device_communicator=SimpleNamespace(ca_comm=None),
+    )
+    monkeypatch.setattr(parallel_state, "get_tp_group", lambda: tp_group)
+    config = SimpleNamespace(
+        compilation_config=SimpleNamespace(max_cudagraph_capture_size=64),
+    )
+
+    with pytest.raises(AssertionError, match="requires custom all-reduce"):
+        assert_hoist_preconditions(config)
+
+
+def test_mhc_custom_op_fake_signatures_match():
+    import inspect
+
+    from vllm.model_executor.kernels.mhc import tilelang as tilelang_mod
+
+    pairs = (
+        (
+            tilelang_mod.mhc_post_tilelang,
+            tilelang_mod._mhc_post_tilelang_fake,
+        ),
+        (
+            tilelang_mod.mhc_fused_post_pre_tilelang,
+            tilelang_mod._mhc_fused_post_pre_tilelang_fake,
+        ),
+    )
+    for implementation, fake in pairs:
+        assert inspect.signature(implementation) == inspect.signature(fake)
+
+
+@pytest.mark.skipif(
+    not HAS_TILELANG_MHC,
+    reason="TileLang MHC support required",
+)
+@pytest.mark.parametrize("num_tokens", [32, 2048])
+@pytest.mark.parametrize("hidden_size", [4096, 7168])
+def test_mhc_post_sqrsum_matches_standalone(num_tokens, hidden_size):
+    from vllm.model_executor.kernels.mhc.tilelang_kernels import (
+        mhc_post_sqrsum_tilelang,
+    )
+
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+    hc_mult = 4
+    x = torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16)
+    residual = torch.randn((num_tokens, hc_mult, hidden_size), dtype=torch.bfloat16)
+    post_layer_mix = torch.randn((num_tokens, hc_mult), dtype=torch.float32)
+    comb_res_mix = torch.randn((num_tokens, hc_mult, hc_mult), dtype=torch.float32)
+
+    out = torch.empty_like(residual)
+    sqrsum = torch.empty((1, num_tokens), dtype=torch.float32)
+    mhc_post_sqrsum_tilelang(
+        comb_res_mix,
+        residual,
+        post_layer_mix,
+        x,
+        out,
+        sqrsum,
+        hc_mult,
+        hidden_size,
+    )
+
+    ref = mhc_post_ref(x, residual, post_layer_mix.unsqueeze(-1), comb_res_mix)
+    ref_sqrsum = out.float().square().sum(dim=(-2, -1)).unsqueeze(0)
+    torch.testing.assert_close(out, ref, atol=5e-2, rtol=1e-2)
+    torch.testing.assert_close(sqrsum, ref_sqrsum, atol=0, rtol=1e-4)
+
+
+@pytest.mark.skipif(
+    not HAS_TILELANG_MHC,
+    reason="TileLang MHC support required",
+)
+@pytest.mark.parametrize("fuse_sqrsum", [False, True])
+def test_mhc_post_int8_matches_dequantized_reference(fuse_sqrsum):
+    from vllm.model_executor.kernels.mhc.ar_int8 import QUANT_BLOCK
+    from vllm.model_executor.kernels.mhc.tilelang_kernels import (
+        mhc_post_int8_tilelang,
+        mhc_post_sqrsum_int8_tilelang,
+    )
+
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+    num_tokens, hc_mult, hidden_size = 32, 4, 4096
+    x_q = torch.randint(-127, 128, (num_tokens, hidden_size), dtype=torch.int8)
+    x_s = torch.rand((num_tokens, hidden_size // QUANT_BLOCK), dtype=torch.bfloat16)
+    residual = torch.randn((num_tokens, hc_mult, hidden_size), dtype=torch.bfloat16)
+    post_layer_mix = torch.randn((num_tokens, hc_mult), dtype=torch.float32)
+    comb_res_mix = torch.randn((num_tokens, hc_mult, hc_mult), dtype=torch.float32)
+
+    out = torch.empty_like(residual)
+    args = [
+        comb_res_mix,
+        residual,
+        post_layer_mix,
+        x_q,
+        x_s,
+        out,
+    ]
+    sqrsum = torch.empty((1, num_tokens), dtype=torch.float32)
+    if fuse_sqrsum:
+        args.append(sqrsum)
+        kernel = mhc_post_sqrsum_int8_tilelang
+    else:
+        kernel = mhc_post_int8_tilelang
+    kernel(*args, hc_mult, hidden_size, QUANT_BLOCK)
+
+    x_dequant = x_q.float() * x_s.float().repeat_interleave(QUANT_BLOCK, dim=-1)
+    ref = (
+        x_dequant.unsqueeze(-2) * post_layer_mix.unsqueeze(-1)
+        + torch.bmm(comb_res_mix.mT, residual.float())
+    ).bfloat16()
+    torch.testing.assert_close(out, ref, atol=5e-2, rtol=1e-2)
+    if fuse_sqrsum:
+        ref_sqrsum = out.float().square().sum(dim=(-2, -1)).unsqueeze(0)
+        torch.testing.assert_close(sqrsum, ref_sqrsum, atol=0, rtol=1e-4)
+
+
 @pytest.mark.skipif(
     not HAS_TILELANG_MHC,
     reason="TileLang MHC support required",

--- a/tests/models/test_deepseek_v4_input_gemm_fusion.py
+++ b/tests/models/test_deepseek_v4_input_gemm_fusion.py
@@ -261,3 +261,112 @@ def test_token_shard_still_declines_below_the_threshold():
 
     assert seen["wqa_wkv_rows"] == n_tokens
     assert qr_kv.shape[0] == n_tokens
+
+
+@pytest.mark.parametrize("use_int8", [False, True])
+def test_hoisted_all_reduce_readds_the_suppressed_collective(monkeypatch, use_int8):
+    import vllm.models.deepseek_v4.nvidia.model as model_mod
+
+    stub = nn.Module()
+    stub._ar_hoisted = True
+    x = torch.ones(32, HIDDEN, dtype=torch.bfloat16)
+    reduced = x + 1
+    codes = torch.ones_like(x, dtype=torch.int8)
+    scales = torch.ones(32, HIDDEN // 32, dtype=torch.bfloat16)
+    seen: list[str] = []
+
+    monkeypatch.setattr(model_mod, "use_int8_for", lambda _: use_int8)
+
+    def reduce_bf16(_):
+        seen.append("bf16")
+        return reduced
+
+    def reduce_int8(_):
+        seen.append("int8")
+        return codes, scales
+
+    monkeypatch.setattr(
+        model_mod,
+        "tensor_model_parallel_all_reduce",
+        reduce_bf16,
+    )
+    monkeypatch.setattr(
+        model_mod,
+        "int8_all_reduce",
+        reduce_int8,
+    )
+
+    actual, actual_scales = model_mod.DeepseekV4DecoderLayer._hoisted_all_reduce(
+        stub, x
+    )
+    if use_int8:
+        assert actual is codes
+        assert actual_scales is scales
+        assert seen == ["int8"]
+    else:
+        assert actual is reduced
+        assert actual_scales is None
+        assert seen == ["bf16"]
+
+
+def test_decoder_carries_int8_scales_to_each_mhc_post(monkeypatch):
+    import vllm.models.deepseek_v4.nvidia.model as model_mod
+
+    class Norm:
+        weight = torch.ones(HIDDEN, dtype=torch.bfloat16)
+        variance_epsilon = 1e-5
+
+    stub = nn.Module()
+    stub.attn_norm = Norm()
+    stub.ffn_norm = Norm()
+    stub.attn = lambda positions, x, _: x
+    stub.ffn = lambda x, input_ids: x
+    stub.hc_attn_fn = torch.empty(24, HIDDEN * 4)
+    stub.hc_ffn_fn = torch.empty(24, HIDDEN * 4)
+    stub.hc_attn_scale = torch.empty(3)
+    stub.hc_ffn_scale = torch.empty(3)
+    stub.hc_attn_base = torch.empty(24)
+    stub.hc_ffn_base = torch.empty(24)
+    stub.rms_norm_eps = 1e-6
+    stub.hc_eps = 1e-6
+    stub.hc_post_alpha = 2.0
+    stub.hc_sinkhorn_iters = 20
+
+    x = torch.ones(4, HIDDEN, dtype=torch.int8)
+    residual = torch.ones(4, 4, HIDDEN, dtype=torch.bfloat16)
+    post_mix = torch.ones(4, 4, 1)
+    res_mix = torch.ones(4, 4, 4)
+    incoming_scales = torch.ones(4, HIDDEN // 32, dtype=torch.bfloat16)
+    attn_scales = incoming_scales + 1
+    ffn_scales = incoming_scales + 2
+    reductions = iter(((x, attn_scales), (x, ffn_scales)))
+    stub._hoisted_all_reduce = lambda _: next(reductions)
+    seen_scales = []
+
+    def fused_post_pre(
+        x,
+        residual,
+        post_mix,
+        res_mix,
+        *args,
+        x_scales=None,
+        **kwargs,
+    ):
+        seen_scales.append(x_scales)
+        return residual, post_mix, res_mix, x.to(torch.bfloat16)
+
+    monkeypatch.setattr(model_mod, "mhc_fused_post_pre_tilelang", fused_post_pre)
+
+    *_, returned_scales = model_mod.DeepseekV4DecoderLayer.forward(
+        stub,
+        x,
+        torch.arange(4),
+        None,
+        post_mix,
+        res_mix,
+        residual,
+        incoming_scales,
+    )
+    assert seen_scales[0] is incoming_scales
+    assert seen_scales[1] is attn_scales
+    assert returned_scales is ffn_scales

--- a/vllm/model_executor/kernels/mhc/ar_int8.py
+++ b/vllm/model_executor/kernels/mhc/ar_int8.py
@@ -53,8 +53,9 @@ def ar_hoisted(vllm_config) -> bool:
     return get_tp_group().world_size > 1
 
 
-def assert_hoist_preconditions(vllm_config, moe_config=None,
-                               routed_output_transform=None) -> None:
+def assert_hoist_preconditions(
+    vllm_config, moe_config=None, routed_output_transform=None
+) -> None:
     """Turn every remaining unknown into a startup failure.
 
     Called at construction with whatever is in scope; each check is skipped only
@@ -68,7 +69,7 @@ def assert_hoist_preconditions(vllm_config, moe_config=None,
     # than merely unlikely. A comment cannot survive someone raising the cap or
     # lowering the threshold; this can.
     cap = getattr(vllm_config.compilation_config, "max_cudagraph_capture_size", 0) or 0
-    assert MIN_INT8_TOKENS > cap, (
+    assert cap < MIN_INT8_TOKENS, (
         f"VLLM_MHC_AR_INT8 requires the int8 token threshold to exceed the "
         f"cudagraph capture cap so prefill is always eager and no replayed "
         f"graph can contain the int8 op; got threshold={MIN_INT8_TOKENS} "
@@ -83,19 +84,22 @@ def assert_hoist_preconditions(vllm_config, moe_config=None,
     # needed. Largest payload is max_num_batched_tokens x hidden x (1 + 1/16).
     from vllm.distributed.parallel_state import get_tp_group
 
-    ca = get_tp_group().device_communicator.ca_comm
-    if ca is not None and not ca.disabled:
-        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        hidden = vllm_config.model_config.get_hidden_size()
-        need = max_tokens * hidden + (max_tokens * hidden // QUANT_BLOCK) * 2
-        assert ca.max_size >= need, (
-            f"VLLM_MHC_AR_INT8 needs the custom all-reduce buffer to hold the "
-            f"int8 payload plus its block scales: need {need / 2**20:.1f} MiB "
-            f"for {max_tokens} tokens x {hidden}, but the communicator was "
-            f"built with {ca.max_size / 2**20:.1f} MiB. Raise "
-            f"VLLM_MAX_SIZE_MB_CUSTOM_ALL_REDUCE to at least "
-            f"{int(need / 2**20) + 1}."
-        )
+    ca = getattr(get_tp_group().device_communicator, "ca_comm", None)
+    assert ca is not None and not ca.disabled, (
+        "VLLM_MHC_AR_INT8 requires custom all-reduce; remove "
+        "--disable-custom-all-reduce"
+    )
+    max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+    hidden = vllm_config.model_config.get_hidden_size()
+    need = max_tokens * hidden + (max_tokens * hidden // QUANT_BLOCK) * 2
+    assert ca.max_size >= need, (
+        f"VLLM_MHC_AR_INT8 needs the custom all-reduce buffer to hold the "
+        f"int8 payload plus its block scales: need {need / 2**20:.1f} MiB "
+        f"for {max_tokens} tokens x {hidden}, but the communicator was "
+        f"built with {ca.max_size / 2**20:.1f} MiB. Raise "
+        f"VLLM_MAX_SIZE_MB_CUSTOM_ALL_REDUCE to at least "
+        f"{int(need / 2**20) + 1}."
+    )
 
     # (3) The pre-transform all-reduce (moe_runner.py:452-460) is mathematically
     # unhoistable: the transform contains RMSNorm, and normalising a partial sum
@@ -150,7 +154,7 @@ def _ca_comm():
     """
     from vllm.distributed.parallel_state import get_tp_group
 
-    ca = get_tp_group().device_communicator.ca_comm
+    ca = getattr(get_tp_group().device_communicator, "ca_comm", None)
     assert ca is not None and not ca.disabled, (
         "VLLM_MHC_AR_INT8 requires the custom all-reduce communicator"
     )

--- a/vllm/model_executor/kernels/mhc/tilelang.py
+++ b/vllm/model_executor/kernels/mhc/tilelang.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import functools
+
 import torch
 
 import vllm.envs as envs
+from vllm.model_executor.kernels.mhc.ar_int8 import QUANT_BLOCK
 from vllm.utils.torch_utils import direct_register_custom_op
 
 # The prenorm GEMM is L2-bound on re-reads of `fn`, not CUDA-core bound: at
@@ -33,7 +36,21 @@ _PRENORM_USE_CUBLAS = True
 # at the HBM ceiling, so nothing is left to tune inside it). mhc_post holds
 # those values in registers one kernel earlier, so folding the reduction in
 # there removes the pass and a launch: measured 498.9 -> 350.6 us at T=8192.
-# Read per call rather than at import so a serving A/B only needs a restart.
+
+
+@functools.cache
+def _fuse_sqrsum_enabled() -> bool:
+    return envs.VLLM_MHC_POST_FUSE_SQRSUM
+
+
+def validate_mhc_optimization_flags() -> None:
+    if envs.VLLM_MHC_PRENORM_SHARD and not _fuse_sqrsum_enabled():
+        raise ValueError(
+            "VLLM_MHC_PRENORM_SHARD requires "
+            "VLLM_MHC_POST_FUSE_SQRSUM=1; without the fused row-sqrsum, "
+            "prenorm sharding is inactive"
+        )
+
 
 # (tile_n, split_k, n_thr) for the small-token fused post+prenorm kernel.
 # Swept over the full product at the shapes decode runs (m=5, 6, 12, 16;
@@ -489,12 +506,52 @@ def mhc_pre_broadcast_tilelang(
     )
 
 
+def mhc_post_int8_tilelang(
+    x_q: torch.Tensor,
+    x_s: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    blk: int = QUANT_BLOCK,
+) -> torch.Tensor:
+    """Run mHC post while consuming a blockwise-int8 all-reduce output."""
+    from vllm.model_executor.kernels.mhc.tilelang_kernels import (
+        mhc_post_int8_tilelang as _mhc_post_int8_kernel,
+    )
+
+    assert x_q.dtype == torch.int8, f"int8 mhc_post got {x_q.dtype}"
+    assert x_s.dtype == torch.bfloat16
+    hidden = residual.shape[-1]
+    assert x_s.shape[-1] == hidden // blk, (
+        f"expected {hidden // blk} scales per token, got {x_s.shape[-1]}"
+    )
+
+    out = torch.empty_like(residual)
+    _mhc_post_int8_kernel(
+        comb_res_mix,
+        residual,
+        post_layer_mix.squeeze(-1),
+        x_q,
+        x_s,
+        out,
+        residual.shape[-2],
+        hidden,
+        blk,
+    )
+    return out
+
+
 def mhc_post_tilelang(
     x: torch.Tensor,
     residual: torch.Tensor,
     post_layer_mix: torch.Tensor,
     comb_res_mix: torch.Tensor,
+    x_scales: torch.Tensor | None = None,
 ) -> torch.Tensor:
+    if x_scales is not None:
+        return mhc_post_int8_tilelang(
+            x, x_scales, residual, post_layer_mix, comb_res_mix
+        )
     from vllm.model_executor.kernels.mhc.tilelang_kernels import (
         mhc_post_tilelang as _mhc_post_kernel,
     )
@@ -529,6 +586,7 @@ def mhc_fused_post_pre_tilelang(
     tile_n: int = 1,
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
+    x_scales: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Run one MHC post block followed by the next MHC pre block.
@@ -544,17 +602,14 @@ def mhc_fused_post_pre_tilelang(
         layer_input_cur: shape (..., hidden_size)
     """
 
-    from vllm.model_executor.kernels.mhc.tilelang_kernels import (
-        compute_num_split,
-        mhc_fused_tilelang,
-        mhc_post_tilelang,
-        mhc_pre_big_fuse_tilelang,
-        mhc_pre_big_fuse_with_norm_tilelang,
-    )
+    from vllm.model_executor.kernels.mhc import tilelang_kernels as _tk
+    from vllm.model_executor.kernels.mhc.tilelang_kernels import compute_num_split
     from vllm.utils.math_utils import cdiv
 
     assert residual.dtype == torch.bfloat16
-    assert x.dtype == torch.bfloat16
+    assert x.dtype == (torch.int8 if x_scales is not None else torch.bfloat16), (
+        f"x is {x.dtype} but x_scales is {'set' if x_scales is not None else 'None'}"
+    )
     assert post_layer_mix.dtype == torch.float32
     assert comb_res_mix.dtype == torch.float32
     assert fn.dtype == torch.float32
@@ -598,6 +653,12 @@ def mhc_fused_post_pre_tilelang(
 
     use_deep_gemm = is_deep_gemm_supported()
     use_small_fma = num_tokens <= 16
+    use_int8_x = x_scales is not None
+    if use_int8_x:
+        assert not use_small_fma, (
+            "the int8 all-reduce is prefill-only; the small-FMA kernel has "
+            "no int8 variant"
+        )
     if use_small_fma:
         tile_n, n_splits, fma_n_thr = _SMALL_FMA_CONFIG
         if (
@@ -656,7 +717,7 @@ def mhc_fused_post_pre_tilelang(
     )
 
     if use_small_fma:
-        mhc_fused_tilelang(
+        _tk.mhc_fused_tilelang(
             comb_res_mix_flat,
             residual_flat,
             post_layer_mix_flat,
@@ -675,32 +736,29 @@ def mhc_fused_post_pre_tilelang(
         )
     else:
         residual_cur_2d = residual_cur.view(num_tokens, hc_mult * hidden_size)
-        fuse_sqrsum = envs.VLLM_MHC_POST_FUSE_SQRSUM and not use_deep_gemm
+        if use_int8_x:
+            assert x_scales is not None
+            assert x_scales.numel() * QUANT_BLOCK == x_flat.numel(), (
+                f"{x_scales.numel()} scales cannot cover {x_flat.numel()} "
+                f"int8 codes at block {QUANT_BLOCK}"
+            )
+        fuse_sqrsum = _fuse_sqrsum_enabled() and not use_deep_gemm
+        post_kernel = {
+            (False, False): _tk.mhc_post_tilelang,
+            (False, True): _tk.mhc_post_sqrsum_tilelang,
+            (True, False): _tk.mhc_post_int8_tilelang,
+            (True, True): _tk.mhc_post_sqrsum_int8_tilelang,
+        }[(use_int8_x, fuse_sqrsum)]
+        post_args = [comb_res_mix_flat, residual_flat, post_layer_mix_flat, x_flat]
+        if x_scales is not None:
+            post_args.append(x_scales.view(num_tokens, -1))
+        post_args.append(residual_cur)
         if fuse_sqrsum:
-            from vllm.model_executor.kernels.mhc.tilelang_kernels import (
-                mhc_post_sqrsum_tilelang,
-            )
-
-            mhc_post_sqrsum_tilelang(
-                comb_res_mix_flat,
-                residual_flat,
-                post_layer_mix_flat,
-                x_flat,
-                residual_cur,
-                gemm_out_sqrsum,
-                residual.shape[-2],
-                residual.shape[-1],
-            )
-        else:
-            mhc_post_tilelang(
-                comb_res_mix_flat,
-                residual_flat,
-                post_layer_mix_flat,
-                x_flat,
-                residual_cur,
-                residual.shape[-2],
-                residual.shape[-1],
-            )
+            post_args.append(gemm_out_sqrsum)
+        post_args += [residual.shape[-2], residual.shape[-1]]
+        if use_int8_x:
+            post_args.append(QUANT_BLOCK)
+        post_kernel(*post_args)
 
         if use_deep_gemm:
             from vllm.utils.deep_gemm import tf32_hc_prenorm_gemm
@@ -724,7 +782,7 @@ def mhc_fused_post_pre_tilelang(
             )
 
     if norm_weight is None:
-        mhc_pre_big_fuse_tilelang(
+        _tk.mhc_pre_big_fuse_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,
             hc_scale,
@@ -743,7 +801,7 @@ def mhc_fused_post_pre_tilelang(
             hc_mult,
         )
     else:
-        mhc_pre_big_fuse_with_norm_tilelang(
+        _tk.mhc_pre_big_fuse_with_norm_tilelang(
             gemm_out_mul,
             gemm_out_sqrsum,
             hc_scale,
@@ -789,6 +847,7 @@ def _mhc_fused_post_pre_tilelang_fake(
     tile_n: int = 1,
     norm_weight: torch.Tensor | None = None,
     norm_eps: float = 1e-6,
+    x_scales: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     hc_mult = residual.shape[-2]
     hidden_size = residual.shape[-1]
@@ -824,6 +883,7 @@ def _mhc_post_tilelang_fake(
     residual: torch.Tensor,
     post_layer_mix: torch.Tensor,
     comb_res_mix: torch.Tensor,
+    x_scales: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(residual)
 

--- a/vllm/model_executor/kernels/mhc/tilelang_kernels.py
+++ b/vllm/model_executor/kernels/mhc/tilelang_kernels.py
@@ -654,6 +654,68 @@ def mhc_fused_tilelang(
 @tilelang.jit(
     pass_configs=pass_configs,
 )
+def mhc_post_int8_tilelang(
+    a,
+    b,
+    c,
+    d_q,
+    d_s,
+    x,
+    hc: int,
+    hidden: int,
+    blk: int = 32,
+    n_thr: int = 128,
+    h_blk: int = 1024,
+) -> tilelang.JITKernel:
+    """Run mHC post while reading a blockwise-int8 layer output."""
+    n = T.dynamic("num_tokens")
+    h = hidden
+
+    h_blk = math.gcd(hidden, h_blk)
+    a: T.Tensor((n, hc, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    b: T.Tensor((n, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    c: T.Tensor((n, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    d_q: T.Tensor((n, h), T.int8)  # type: ignore[no-redef, valid-type]
+    d_s: T.Tensor((n, h // blk), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    x: T.Tensor((n, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    with T.Kernel(n, threads=n_thr) as i_n:
+        b_shared = T.alloc_shared((hc, h_blk), T.bfloat16)
+        dq_shared = T.alloc_shared(h_blk, T.int8)
+        ds_shared = T.alloc_shared(h_blk // blk, T.bfloat16)
+
+        x_local = T.alloc_fragment((hc, h_blk), T.float32)
+        b_local = T.alloc_fragment((hc, h_blk), T.float32)
+        d_local = T.alloc_fragment(h_blk, T.float32)
+
+        a_local = T.alloc_fragment((hc, hc), T.float32)
+        c_local = T.alloc_fragment(hc, T.float32)
+        if ENABLE_PDL:
+            T.pdl_sync()
+        T.copy(a[i_n, 0, 0], a_local)
+        T.copy(c[i_n, 0], c_local)
+
+        for i0_h in T.Serial(T.ceildiv(h, h_blk)):
+            T.copy(b[i_n, 0, i0_h * h_blk], b_shared)
+            T.copy(d_q[i_n, i0_h * h_blk], dq_shared)
+            T.copy(d_s[i_n, i0_h * h_blk // blk], ds_shared)
+
+            T.copy(b_shared, b_local)
+            for i1_h in T.Parallel(h_blk):
+                d_local[i1_h] = dq_shared[i1_h] * ds_shared[i1_h // blk]
+
+            for i_hco, i1_h in T.Parallel(hc, h_blk):
+                x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                for i_hci in T.vectorized(hc):
+                    x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+
+            T.copy(x_local, x[i_n, 0, i0_h * h_blk])
+        if ENABLE_PDL:
+            T.pdl_trigger()
+
+
+@tilelang.jit(
+    pass_configs=pass_configs,
+)
 def mhc_post_tilelang(
     a,
     b,
@@ -702,6 +764,153 @@ def mhc_post_tilelang(
                     x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
 
             T.copy(x_local, x[i_n, 0, i0_h * h_blk])
+        if ENABLE_PDL:
+            T.pdl_trigger()
+
+
+@tilelang.jit(
+    pass_configs=pass_configs,
+)
+def mhc_post_sqrsum_int8_tilelang(
+    a,
+    b,
+    c,
+    d_q,
+    d_s,
+    x,
+    sqrsum,
+    hc: int,
+    hidden: int,
+    blk: int = 32,
+    n_thr: int = 128,
+    h_blk: int = 1024,
+) -> tilelang.JITKernel:
+    """Run int8 mHC post and produce the prenorm row sum-of-squares."""
+    n = T.dynamic("num_tokens")
+    h = hidden
+
+    h_blk = math.gcd(hidden, h_blk)
+    a: T.Tensor((n, hc, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    b: T.Tensor((n, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    c: T.Tensor((n, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    d_q: T.Tensor((n, h), T.int8)  # type: ignore[no-redef, valid-type]
+    d_s: T.Tensor((n, h // blk), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    x: T.Tensor((n, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    sqrsum: T.Tensor((1, n), T.float32)  # type: ignore[no-redef, valid-type]
+    with T.Kernel(n, threads=n_thr) as i_n:
+        b_shared = T.alloc_shared((hc, h_blk), T.bfloat16)
+        dq_shared = T.alloc_shared(h_blk, T.int8)
+        ds_shared = T.alloc_shared(h_blk // blk, T.bfloat16)
+
+        x_local = T.alloc_fragment((hc, h_blk), T.float32)
+        b_local = T.alloc_fragment((hc, h_blk), T.float32)
+        d_local = T.alloc_fragment(h_blk, T.float32)
+        sq_acc = T.alloc_fragment((hc, h_blk), T.float32)
+
+        a_local = T.alloc_fragment((hc, hc), T.float32)
+        c_local = T.alloc_fragment(hc, T.float32)
+        if ENABLE_PDL:
+            T.pdl_sync()
+        T.copy(a[i_n, 0, 0], a_local)
+        T.copy(c[i_n, 0], c_local)
+        T.clear(sq_acc)
+
+        for i0_h in T.Serial(T.ceildiv(h, h_blk)):
+            T.copy(b[i_n, 0, i0_h * h_blk], b_shared)
+            T.copy(d_q[i_n, i0_h * h_blk], dq_shared)
+            T.copy(d_s[i_n, i0_h * h_blk // blk], ds_shared)
+
+            T.copy(b_shared, b_local)
+            for i1_h in T.Parallel(h_blk):
+                d_local[i1_h] = dq_shared[i1_h] * ds_shared[i1_h // blk]
+
+            for i_hco, i1_h in T.Parallel(hc, h_blk):
+                x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                for i_hci in T.vectorized(hc):
+                    x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+
+            for i_hco, i1_h in T.Parallel(hc, h_blk):
+                xb = T.float32(T.bfloat16(x_local[i_hco, i1_h]))
+                sq_acc[i_hco, i1_h] += xb * xb
+
+            T.copy(x_local, x[i_n, 0, i0_h * h_blk])
+
+        sq_row = T.alloc_fragment(hc, T.float32)
+        sq_tot = T.alloc_fragment(1, T.float32)
+        T.reduce_sum(sq_acc, sq_row, dim=1)
+        T.reduce_sum(sq_row, sq_tot, dim=0)
+        if T.get_thread_binding() == 0:
+            sqrsum[0, i_n] = sq_tot[0]
+        if ENABLE_PDL:
+            T.pdl_trigger()
+
+
+@tilelang.jit(
+    pass_configs=pass_configs,
+)
+def mhc_post_sqrsum_tilelang(
+    a,
+    b,
+    c,
+    d,
+    x,
+    sqrsum,
+    hc: int,
+    hidden: int,
+    n_thr: int = 128,
+    h_blk: int = 1024,
+) -> tilelang.JITKernel:
+    """Run mHC post and produce the prenorm row sum-of-squares."""
+    n = T.dynamic("num_tokens")
+    h = hidden
+
+    h_blk = math.gcd(hidden, h_blk)
+    a: T.Tensor((n, hc, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    b: T.Tensor((n, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    c: T.Tensor((n, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    d: T.Tensor((n, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    x: T.Tensor((n, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    sqrsum: T.Tensor((1, n), T.float32)  # type: ignore[no-redef, valid-type]
+    with T.Kernel(n, threads=n_thr) as i_n:
+        b_shared = T.alloc_shared((hc, h_blk), T.bfloat16)
+        d_shared = T.alloc_shared(h_blk, T.bfloat16)
+
+        x_local = T.alloc_fragment((hc, h_blk), T.float32)
+        b_local = T.alloc_fragment((hc, h_blk), T.float32)
+        d_local = T.alloc_fragment(h_blk, T.float32)
+        sq_acc = T.alloc_fragment((hc, h_blk), T.float32)
+
+        a_local = T.alloc_fragment((hc, hc), T.float32)
+        c_local = T.alloc_fragment(hc, T.float32)
+        if ENABLE_PDL:
+            T.pdl_sync()
+        T.copy(a[i_n, 0, 0], a_local)
+        T.copy(c[i_n, 0], c_local)
+        T.clear(sq_acc)
+
+        for i0_h in T.Serial(T.ceildiv(h, h_blk)):
+            T.copy(b[i_n, 0, i0_h * h_blk], b_shared)
+            T.copy(d[i_n, i0_h * h_blk], d_shared)
+
+            T.copy(b_shared, b_local)
+            T.copy(d_shared, d_local)
+            for i_hco, i1_h in T.Parallel(hc, h_blk):
+                x_local[i_hco, i1_h] = c_local[i_hco] * d_local[i1_h]
+                for i_hci in T.vectorized(hc):
+                    x_local[i_hco, i1_h] += a_local[i_hci, i_hco] * b_local[i_hci, i1_h]
+
+            for i_hco, i1_h in T.Parallel(hc, h_blk):
+                xb = T.float32(T.bfloat16(x_local[i_hco, i1_h]))
+                sq_acc[i_hco, i1_h] += xb * xb
+
+            T.copy(x_local, x[i_n, 0, i0_h * h_blk])
+
+        sq_row = T.alloc_fragment(hc, T.float32)
+        sq_tot = T.alloc_fragment(1, T.float32)
+        T.reduce_sum(sq_acc, sq_row, dim=1)
+        T.reduce_sum(sq_row, sq_tot, dim=0)
+        if T.get_thread_binding() == 0:
+            sqrsum[0, i_n] = sq_tot[0]
         if ENABLE_PDL:
             T.pdl_trigger()
 

--- a/vllm/models/deepseek_v4/nvidia/dspark.py
+++ b/vllm/models/deepseek_v4/nvidia/dspark.py
@@ -177,13 +177,16 @@ class DSparkDeepseekV4Model(nn.Module):
 
         residual = post_mix = res_mix = None
         for layer in self.layers:
-            hidden_states, residual, post_mix, res_mix = layer(
+            hidden_states, residual, post_mix, res_mix, x_scales = layer(
                 hidden_states,
                 positions,
                 input_ids,
-                post_mix,
-                res_mix,
-                residual,
+                post_mix=post_mix,
+                res_mix=res_mix,
+                residual=residual,
+            )
+            assert x_scales is None, (
+                "DSpark drafter is decode-only; the int8 AR is prefill-only"
             )
         hidden_states = mhc_post_tilelang(hidden_states, residual, post_mix, res_mix)
         # hc_head reduces the hc copies; return the PRE-norm head hidden

--- a/vllm/models/deepseek_v4/nvidia/model.py
+++ b/vllm/models/deepseek_v4/nvidia/model.py
@@ -16,14 +16,22 @@ from vllm.distributed import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
 )
+from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
 from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.model_executor.kernels.mhc.ar_int8 import (
+    ar_hoisted,
+    assert_hoist_preconditions,
+    int8_all_reduce,
+    use_int8_for,
+)
 from vllm.model_executor.kernels.mhc.tilelang import (
     hc_head_fused_kernel_tilelang,
     mhc_fused_post_pre_tilelang,
     mhc_post_tilelang,
     mhc_pre_broadcast_tilelang,
     mhc_pre_tilelang,
+    validate_mhc_optimization_flags,
 )
 from vllm.model_executor.layers.activation import SiluAndMul, SiluAndMulWithClamp
 from vllm.model_executor.layers.fused_moe import (
@@ -525,6 +533,10 @@ class DeepseekV4MoE(nn.Module):
         self.use_mega_moe = (
             vllm_config.kernel_config.moe_backend == "deep_gemm_mega_moe"
         )
+        if self.use_mega_moe and ar_hoisted(vllm_config):
+            raise ValueError(
+                "VLLM_MHC_AR_INT8 is not supported with deep_gemm_mega_moe"
+            )
         if self.use_mega_moe and not vllm_config.parallel_config.enable_expert_parallel:
             raise NotImplementedError(
                 "DeepSeek V4 MegaMoE currently requires expert parallel. "
@@ -670,6 +682,7 @@ class DeepseekV4MoE(nn.Module):
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
         self.physical_expert_start = self.experts_start_idx
         self.physical_expert_end = self.experts_end_idx
+        hoisted = ar_hoisted(vllm_config)
 
         self.experts = FusedMoEFactory(
             shared_experts=self.shared_experts,
@@ -689,7 +702,17 @@ class DeepseekV4MoE(nn.Module):
             router_logits_dtype=torch.float32,
             enable_eplb=parallel_config.enable_eplb,
             num_redundant_experts=eplb_config.num_redundant_experts,
+            reduce_results=not hoisted,
         )
+
+        if hoisted:
+            assert_hoist_preconditions(
+                vllm_config,
+                moe_config=self.experts.moe_config,
+                routed_output_transform=getattr(
+                    self.experts, "routed_output_transform", None
+                ),
+            )
 
     def forward(
         self, hidden_states: torch.Tensor, input_ids: torch.Tensor | None = None
@@ -821,7 +844,9 @@ class DeepseekV4DecoderLayer(nn.Module):
     ):
         super().__init__()
 
+        validate_mhc_optimization_flags()
         config = vllm_config.model_config.hf_config
+        self._ar_hoisted = ar_hoisted(vllm_config)
         self.hidden_size = config.hidden_size
 
         self.rms_norm_eps = config.rms_norm_eps
@@ -886,6 +911,15 @@ class DeepseekV4DecoderLayer(nn.Module):
             requires_grad=False,
         )
 
+    def _hoisted_all_reduce(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        if not self._ar_hoisted:
+            return x, None
+        if use_int8_for(x):
+            return int8_all_reduce(x)
+        return tensor_model_parallel_all_reduce(x), None
+
     def forward(
         self,
         x: torch.Tensor,
@@ -894,7 +928,14 @@ class DeepseekV4DecoderLayer(nn.Module):
         post_mix: torch.Tensor | None = None,
         res_mix: torch.Tensor | None = None,
         residual: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        x_scales: torch.Tensor | None = None,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
         attn_norm_weight = self.attn_norm.weight.data
         attn_norm_eps = self.attn_norm.variance_epsilon
         if residual is None:
@@ -948,10 +989,12 @@ class DeepseekV4DecoderLayer(nn.Module):
                 tile_n=1,
                 norm_weight=attn_norm_weight,
                 norm_eps=attn_norm_eps,
+                x_scales=x_scales,
             )
 
         # attn_norm is fused into mhc_pre_tilelang / mhc_fused_post_pre above.
         x = self.attn(positions, x, None)
+        x, x_scales = self._hoisted_all_reduce(x)
 
         ffn_norm_weight = self.ffn_norm.weight.data
         ffn_norm_eps = self.ffn_norm.variance_epsilon
@@ -972,10 +1015,12 @@ class DeepseekV4DecoderLayer(nn.Module):
             tile_n=1,
             norm_weight=ffn_norm_weight,
             norm_eps=ffn_norm_eps,
+            x_scales=x_scales,
         )
 
         x = self.ffn(x, input_ids)
-        return x, residual, post_mix, res_mix
+        x, x_scales = self._hoisted_all_reduce(x)
+        return x, residual, post_mix, res_mix, x_scales
 
 
 def _drafter_needs_target_embed(vllm_config: VllmConfig) -> bool:
@@ -1052,8 +1097,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # Costs one extra vocab-parallel table on the last stage only
         # (129280x4096 bf16 = 1.06 GB, ~265 MB/GPU at TP4).
         needs_embed = get_pp_group().is_first_rank or (
-            get_pp_group().is_last_rank
-            and _drafter_needs_target_embed(vllm_config)
+            get_pp_group().is_last_rank and _drafter_needs_target_embed(vllm_config)
         )
         if needs_embed:
             self.embed_tokens = VocabParallelEmbedding(
@@ -1157,24 +1201,26 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
             input_ids = input_ids.to(torch.int64)
 
         residual, post_mix, res_mix = None, None, None
+        x_scales: torch.Tensor | None = None
         aux_hidden_states: list[torch.Tensor] = []
         final_aux_recon: torch.Tensor | None = None  # avoid duplicate mhc_post call
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer),
             start=self.start_layer,
         ):
-            hidden_states, residual, post_mix, res_mix = layer(
+            hidden_states, residual, post_mix, res_mix, x_scales = layer(
                 hidden_states,
                 positions,
                 input_ids,
                 post_mix,
                 res_mix,
                 residual,
+                x_scales,
             )
             if idx + 1 in self.aux_hidden_state_layers:
                 # Reconstruct the aux hidden state for draft models
                 aux_recon = mhc_post_tilelang(
-                    hidden_states, residual, post_mix, res_mix
+                    hidden_states, residual, post_mix, res_mix, x_scales=x_scales
                 )
                 aux_hidden_states.append(aux_recon.mean(dim=1))
                 final_aux_recon = aux_recon
@@ -1184,7 +1230,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 hidden_states = final_aux_recon
             else:
                 hidden_states = mhc_post_tilelang(
-                    hidden_states, residual, post_mix, res_mix
+                    hidden_states, residual, post_mix, res_mix, x_scales=x_scales
                 )
 
         if not get_pp_group().is_last_rank:

--- a/vllm/models/deepseek_v4/nvidia/mtp.py
+++ b/vllm/models/deepseek_v4/nvidia/mtp.py
@@ -161,10 +161,16 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         hidden_states = self.h_proj(previous_hidden_states) + self.e_proj(
             inputs_embeds
         ).unsqueeze(-2)
-        hidden_states, residual, post_mix, res_mix = self.mtp_block(
+        hidden_states, residual, post_mix, res_mix, x_scales = self.mtp_block(
             positions=positions, x=hidden_states, input_ids=None
         )
-        hidden_states = mhc_post_tilelang(hidden_states, residual, post_mix, res_mix)
+        hidden_states = mhc_post_tilelang(
+            hidden_states,
+            residual,
+            post_mix,
+            res_mix,
+            x_scales=x_scales,
+        )
         # Return the flat pre-hc_head residual so it can be re-fed as the
         # next spec step's `previous_hidden_states` when
         # num_speculative_tokens > 1. hc_head is deferred to compute_logits.


### PR DESCRIPTION

## What this fixes

Two flags documented in the README as opt-in performance knobs are broken on the shipped `v0.6.6-sm80` image (`e8953f6e5`):

- **#28** — `VLLM_MHC_POST_FUSE_SQRSUM=1` crashes at worker profiling: `tilelang.py` imports `mhc_post_sqrsum_tilelang`, which was never ported to `tilelang_kernels.py`. Because `VLLM_MHC_PRENORM_SHARD` is deliberately coupled to the fused sqrsum, it is silently inactive as well.
- **#29** — `VLLM_MHC_AR_INT8=1` suppresses the attention TP all-reduce (`attention.py`: `reduce_results=not ar_hoisted`) but nothing re-adds it: `nvidia/model.py` at `e8953f6e5` has no `_hoisted_all_reduce`, no int8 TileLang consumers exist, and the native `all_reduce_int8` op is absent — every output is rank-local garbage with no crash.

This PR ports the missing pieces from the A100 campaign tree: the decoder-side hoisted all-reduce (int8 above the 2048-token threshold, bf16 below), the int8/sqrsum TileLang post kernels, the native `all_reduce_int8` transport, the PP `x_scales` handoff, and a flag-enabled test.

## Test commands and results

All on 8×A100-SXM4-40GB (NVSwitch, driver 610.57.04), model `deepseek-ai/DeepSeek-V4-Flash-0731`, TP=8, 512K max-model-len, DSpark k=5. Image built from this branch on the target host.

- `python3 -m pytest tests/models/test_deepseek_v4_input_gemm_fusion.py -v` → **16 passed in 13.54 s** (run on the 8×A100 target, in a container from this branch's image; includes `test_hoisted_all_reduce_readds_the_suppressed_collective` and `test_decoder_carries_int8_scales_to_each_mhc_post`)
- End-to-end A/B on the built image (each arm: greedy sanity, 32k c8/c16/c64 decode sweep, gsm8k-100 @16-shot nc=8):
  - control: sanity ✓, gsm8k 0.96, c8/c16/c64 = 165/300/334 steps/s
  - +AR_INT8: sanity ✓ (was gibberish on `e8953f6e5`), gsm8k 0.96, decode-neutral
  - +SQRSUM/PRENORM: boots (was ImportError), sanity ✓, gsm8k 0.95, decode-neutral
  - all three: sanity ✓, gsm8k 0.95, decode-neutral
- Cold-prefill A/B (standalone, 8k/64k): control 11,072/12,556 tok/s → all three flags **11,575/13,259 tok/s (+4.5%/+5.6%)**; AR_INT8 alone −20 ms TTFT@8k (campaign measured −18.75 ms on A100-80GB).
- Full serving certification of the production candidate (this branch, max-num-seqs 16, capture cap 96, 8448/8192, util 0.875): 342k-token needle retrieval ✓, **gsm8k-200 @16-shot nc=8 = 0.975 ± 0.011**, tool-call parser ✓, zero allocator OOM events, archive matrix c1–c16 clean.

## Model evaluation

gsm8k scores above; all certified configs sit within each other's confidence intervals and match the shipped-image baseline (0.965 ± 0.013) — the recovered flags are quality-neutral.

## Build note (pre-existing, NOT addressed by this PR)

Fresh cache-less CUDA-13 builds of **any** branch (including the current default branch) fail in the DeepEP stage before reaching this PR's changes: `tools/ep_kernels/install_python_libraries.sh` installs unpinned `torch`, which resolves cu12.x wheels under the CUDA 13.0.3 base and aborts on DeepEP's CUDA check; additionally torch `2.13.0+cu130` pins `nvidia-nccl-cu13==2.28.3.post1`, which no longer exists on any index. CI is shielded by its registry build-cache. This is an independent defect tracked separately; local workaround used for the verification builds here: pin `torch==2.13.0` with the cu130 extra index under `UV_OVERRIDE` mapping `nvidia-nccl-cu13` to `2.30.7`.

## AI assistance statement

AI assistance was used in developing and verifying this change. Every changed line was reviewed by the human submitter, and all test and benchmark results were measured on the target hardware described.
