### PR TITLE
fix(glm5next): fix MTP and repo ID startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,57 @@ curl http://localhost:8000/v1/models
 ### General Tips
 
 - `FULL_AND_PIECEWISE` captures the whole decode step — attention, MoE dispatch, NCCL all-reduce and the DSpark draft loop — into one CUDA graph. Measured on 4x/8x A6000: single-stream decode 45.6 -> 67-70 tok/s (+47%); prefill is unchanged (compute-bound). Two prerequisites:
-  - Pin NCCL with `NCCL_ALGO=Ring NCCL_PROTO=Simple` (and prefer `--disable-custom-all-reduce`). Graph replay must re-issue the exact captured collective; NCCL's size-adaptive algorithm switching is what made FULL capture "crash on Ampere" — Ampere itself is fine.
-  - Bound `cudagraph_capture_sizes` as shown. FULL graphs keep private memory pools; capturing every batch size up to `--max-num-seqs` can cost >800 MB per GPU and OOM warmup at high `--gpu-memory-utilization`.
+    - Pin NCCL with `NCCL_ALGO=Ring NCCL_PROTO=Simple` (and prefer `--disable-custom-all-reduce`). Graph replay must re-issue the exact captured collective; NCCL's size-adaptive algorithm switching is what made FULL capture "crash on Ampere" — Ampere itself is fine.
+    - Bound `cudagraph_capture_sizes` as shown. FULL graphs keep private memory pools; capturing every batch size up to `--max-num-seqs` can cost >800 MB per GPU and OOM warmup at high `--gpu-memory-utilization`.
 - Adjust your TP (--tensor-parallel-size), PP (--pipeline-parallel-size) and EP (--enable-expert-parallel) accordingly.
 
-
 ### Model Specific setups
+
+#### GLM-5.3-Flash (`latest-sm80`)
+
+The AWQ W4A16 checkpoint has been verified with MTP speculative decoding on
+4x A100-80GB. The following command serves it directly from its Hugging Face
+repository ID; no source patching or manual snapshot-path resolution is needed:
+
+```bash
+docker run --rm \
+  --gpus all \
+  --ipc=host \
+  -p 8000:8000 \
+  -v ~/.cache/huggingface:/root/.cache/huggingface \
+  -e HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN:-} \
+  -e NCCL_ALGO=Ring \
+  -e NCCL_PROTO=Simple \
+  lazymio/vllm-backport:latest-sm80 \
+  wtdcode/GLM-5.3-Flash-AWQ-W4A16 \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --tensor-parallel-size 4 \
+  --max-model-len 524288 \
+  --gpu-memory-utilization 0.92 \
+  --kv-cache-dtype bfloat16 \
+  --max-num-seqs 16 \
+  --max-num-batched-tokens 8192 \
+  --enable-chunked-prefill \
+  --enable-prefix-caching \
+  --enable-prompt-tokens-details \
+  --disable-custom-all-reduce \
+  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8,16],"max_cudagraph_capture_size":16}' \
+  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
+  --enable-auto-tool-choice \
+  --tool-call-parser glm47 \
+  --reasoning-parser glm45 \
+  --served-model-name GLM-5.3-Flash
+```
+
+Observed single-stream decode throughput with MTP-3 on 4x A100-80GB:
+
+| MTP acceptance rate | Decode throughput |
+| --- | --- |
+| 40-50% | 90-100 tok/s |
+| 50-60% | 100-112 tok/s |
+| 70-80% | 125-135 tok/s |
+| 90%+ | 145-155 tok/s |
 
 #### Qwen3.8-Flash-Next (v0.9.0+)
 
@@ -129,8 +174,7 @@ vllm serve /path/to/your/qwen3.8 \
 
 - `VLLM_PLE_CPU_OFFLOAD=1` keeps the 51B n-gram embedding (fp8, ~51 GiB) in pinned host RAM via a separate `PleOffloadWorker` process. Without it the TP-sharded embedding adds ~12.8 GiB per GPU and KV memory goes negative on 48 GB cards.
 - `--enable-expert-parallel` is required, not optional: with plain TP the 640-wide expert intermediate becomes 160 per rank, which is not a multiple of the 128x128 fp8 block, and vLLM then forces the Triton fp8 MoE kernel (no fp8 tensor cores on sm86). With EP the experts stay whole and the Marlin W8A16 backend is used.
-- AWQ W4A16 ([`wtdcode/Qwen3.8-Flash-Next-AWQ-W4A16`](https://huggingface.co/wtdcode/Qwen3.8-Flash-Next-AWQ-W4A16), compressed-tensors `pack-quantized`, routed experts INT4 g128, everything else BF16): MTP speculative decoding works (the BF16 MTP draft is kept unquantized automatically). Verified on 4x A100-80GB: `VLLM_PLE_CPU_OFFLOAD=1 vllm serve wtdcode/Qwen3.8-Flash-Next-AWQ-W4A16 --tensor-parallel-size 4 --enable-expert-parallel --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}' --speculative-config '{"method":"mtp","num_speculative_tokens":3}'`. This achives up to 936 tps.
-
+- AWQ W4A16 ([`wtdcode/Qwen3.8-Flash-Next-AWQ-W4A16`](https://huggingface.co/wtdcode/Qwen3.8-Flash-Next-AWQ-W4A16), compressed-tensors `pack-quantized`, routed experts INT4 g128, everything else BF16): MTP speculative decoding works (the BF16 MTP draft is kept unquantized automatically). Verified on 4x A100-80GB: `VLLM_PLE_CPU_OFFLOAD=1 vllm serve wtdcode/Qwen3.8-Flash-Next-AWQ-W4A16 --tensor-parallel-size 4 --enable-expert-parallel --compilation-config '{"mode":0,"cudagraph_mode":"FULL_DECODE_ONLY"}' --speculative-config '{"method":"mtp","num_speculative_tokens":3}'`. This achieves up to 936 tps.
 
 #### DeepSeek V4 Flash
 
@@ -151,4 +195,4 @@ vllm serve /path/to/your/deepseek \
 
 - Keep `num_speculative_tokens` at 5 on Ampere. Values below 5 (the checkpoint's `dspark_block_size`) are rejected, and 7 needs ~200 KB of shared memory vs the 163 KB Ampere limit (`triton OutOfResources` error). 6 does start, but draft positions past the native block are almost never accepted (3–13% in our measurements), so it only wastes draft compute — output quality and speed are the same as 5.
 - Requests that set neither `thinking` nor `reasoning_effort` now get thinking mode with high effort, matching the official 0731 API mapping (`reasoning_effort: "none"` restores plain chat mode). Agentic/tool-calling clients should pass a `reasoning_effort` explicitly from the first turn of a session — sessions that run without the effort prefix gradually stop thinking and can enter self-reinforcing reasoning loops.
-- `--hf-overrides '{"head_dtype": "float32"}'` once helpped reduce garbage outputs by improving precisions but might be not compulsory.
+- `--hf-overrides '{"head_dtype": "float32"}'` once helped reduce garbage outputs by improving precisions but might be not compulsory.

--- a/tests/transformers_utils/processors/test_glm5next.py
+++ b/tests/transformers_utils/processors/test_glm5next.py
@@ -3,6 +3,7 @@
 """Unit tests for the vLLM-native GLM-5.3-Flash multimodal processor."""
 
 import math
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -10,8 +11,10 @@ from PIL import Image
 from transformers.image_utils import PILImageResampling
 from transformers.video_utils import VideoMetadata
 
+import vllm.transformers_utils.processors.glm5next as glm5next_module
 from vllm.transformers_utils.processors.glm5next import (
     Glm5NextImageProcessor,
+    Glm5NextProcessor,
     Glm5NextVideoProcessor,
     _get_pad_content_size,
     _resize_or_pad,
@@ -387,3 +390,41 @@ def test_video_config_fields_land():
         )
         == 16
     )
+
+
+def test_processor_from_pretrained_resolves_hf_repo_config(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class CapturingProcessor(Glm5NextProcessor):
+        def __init__(self, **components):
+            self.components = components
+
+    tokenizer = object()
+    tokenizer_loader = Mock(return_value=tokenizer)
+    image_config_loader = Mock(
+        return_value={"image_processor_type": "Glm5NextImageProcessor"}
+    )
+    processor_config_loader = Mock(
+        return_value={
+            "video_processor": {
+                "video_processor_type": "Glm5NextVideoProcessor",
+                "max_image_tokens": 240000,
+            }
+        }
+    )
+    monkeypatch.setattr("transformers.AutoTokenizer.from_pretrained", tokenizer_loader)
+    monkeypatch.setattr(
+        glm5next_module, "get_image_processor_config", image_config_loader
+    )
+    monkeypatch.setattr(glm5next_module, "get_hf_file_to_dict", processor_config_loader)
+
+    repo_id = "wtdcode/GLM-5.3-Flash-AWQ-W4A16"
+    processor = CapturingProcessor.from_pretrained(repo_id, revision="test-revision")
+
+    tokenizer_loader.assert_called_once_with(repo_id, revision="test-revision")
+    image_config_loader.assert_called_once_with(repo_id)
+    processor_config_loader.assert_called_once_with(
+        "processor_config.json", repo_id, revision="test-revision"
+    )
+    assert processor.components["tokenizer"] is tokenizer
+    assert processor.components["video_processor"].max_image_tokens == 30000

--- a/tests/v1/spec_decode/test_eagle_draft_attn_metadata.py
+++ b/tests/v1/spec_decode/test_eagle_draft_attn_metadata.py
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for the EAGLE speculator's draft attention metadata builder.
 
-These tests guard the regression where ``_build_draft_attn_metadata`` did
-not populate ``seq_lens_cpu_upper_bound`` on the per-step
-``CommonAttentionMetadata``. Several downstream attention backends and
-helpers (``split_decodes_prefills_and_extends``, the MLA indexer,
-flex-attention, cross-attention) assert this field is non-None, so
-omitting it caused crashes at the start of draft decode for certain
-backends (e.g. ``ROCM_AITER_FA`` with eagle/eagle3 spec decode):
-
-    AssertionError: assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
+These tests guard regressions where ``_build_draft_attn_metadata`` did not
+populate fields needed by attention backends on the per-step
+``CommonAttentionMetadata``. Several downstream attention backends and helpers
+require ``seq_lens_cpu_upper_bound`` or ``positions``, so omitting either can
+cause crashes at the start of draft decode.
 """
 
 from types import SimpleNamespace
@@ -37,6 +33,7 @@ def _make_fake_speculator(
     fake_input_buffers = SimpleNamespace(
         query_start_loc=torch.zeros(max_num_reqs + 1, dtype=torch.int32),
         seq_lens=torch.zeros(max_num_reqs, dtype=torch.int32),
+        positions=torch.arange(max_num_tokens, dtype=torch.int64),
     )
     fake_block_tables = SimpleNamespace(
         input_block_tables=[torch.zeros(max_num_reqs, 4, dtype=torch.int32)],
@@ -95,6 +92,23 @@ def test_build_draft_attn_metadata_sets_seq_lens_cpu_upper_bound():
     assert bound.dtype == torch.int32
     # base[:num_reqs] + step, padded tail zeroed.
     assert torch.equal(bound, torch.tensor([102, 202, 302, 0], dtype=torch.int32))
+
+
+def test_build_draft_attn_metadata_sets_positions():
+    fake = _make_fake_speculator()
+
+    captured = _run_build(
+        fake,
+        num_reqs=3,
+        num_reqs_padded=4,
+        num_tokens_padded=5,
+        base=torch.tensor([100, 200, 300, 0], dtype=torch.int32),
+        step=2,
+    )
+
+    positions = captured["positions"]
+    assert isinstance(positions, torch.Tensor)
+    assert torch.equal(positions, fake.input_buffers.positions[:5])
 
 
 def test_build_draft_attn_metadata_handles_zero_unpadded_reqs():

--- a/vllm/transformers_utils/processors/glm5next.py
+++ b/vllm/transformers_utils/processors/glm5next.py
@@ -2,9 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """vLLM-native multimodal processor for GLM-5.3-Flash."""
 
-import json
 import math
-import os
 
 import numpy as np
 import torch
@@ -42,6 +40,8 @@ from transformers.video_utils import (
     group_videos_by_shape,
     reorder_videos,
 )
+
+from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
 logger = logging.get_logger(__name__)
 
@@ -822,8 +822,17 @@ class Glm5NextProcessor(ProcessorMixin):
             **{k: v for k, v in ip_cfg.items() if k != "image_processor_type"}
         )
 
-        with open(os.path.join(model_path, "processor_config.json")) as f:
-            vp_cfg = _cap_cfg(dict(json.load(f)["video_processor"]), is_video=True)
+        processor_config = get_hf_file_to_dict(
+            "processor_config.json",
+            model_path,
+            revision=kwargs.get("revision", "main"),
+        )
+        video_processor_config = (processor_config or {}).get("video_processor")
+        if not isinstance(video_processor_config, dict):
+            raise ValueError(
+                f"processor_config.json for {model_path} is missing video_processor"
+            )
+        vp_cfg = _cap_cfg(dict(video_processor_config), is_video=True)
         video_processor = Glm5NextVideoProcessor(
             **{k: v for k, v in vp_cfg.items() if k != "video_processor_type"}
         )

--- a/vllm/v1/worker/gpu/spec_decode/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/speculator.py
@@ -306,6 +306,7 @@ class DraftModelSpeculator(BaseSpeculator):
             kv_cache_config=self.kv_cache_config,
             causal=causal,
             seq_lens_cpu_upper_bound=draft_seq_lens_cpu_upper_bound,
+            positions=self.input_buffers.positions[:num_tokens_padded],
         )
         return attn_metadata
 


### PR DESCRIPTION
## Summary

- Pass token positions into draft attention metadata, fixing GLM-5.3 MTP startup with the Kpool tail attention backend.
- Resolve `processor_config.json` through the Hugging Face repository helper, allowing GLM-5.3 to be served directly from a repository ID.
- Add regression tests for both fixes.
- Document a verified `latest-sm80` Docker deployment for GLM-5.3-Flash AWQ W4A16.

## Duplicate work check

Checked the upstream open pull requests for GLM-5.3 processor configuration and speculative decoding metadata fixes. No existing pull request addresses these issues.

## A100 validation

The equivalent MTP positions fix has been validated on 4x NVIDIA A100-80GB with MTP-3 enabled.

Observed single-stream decode throughput:

| MTP acceptance rate | Decode throughput |
| --- | --- |
| 40-50% | 90-100 tok/s |
| 50-60% | 100-112 tok/s |
| 70-80% | 125-135 tok/s |
| 90%+ | 145-155 tok/s |

## Tests

- `pre-commit run --files <changed files>`: passed
- `pytest tests/transformers_utils/processors/test_glm5next.py`: 39 passed
- The draft-metadata test cannot be collected on macOS because the existing GPU import path requires Triton. It is intended to run in Linux/CUDA CI.

No separate model-accuracy evaluation was run because this change does not modify model weights, logits, sampling, or output semantics.

## AI assistance

AI assistance was used to prepare this change. The submitter reviewed and is responsible for all changed lines.