### PR TITLE
Enable PP for Qwen3.8-Flash-Next with PLE CPU offload + native MTP

### DIFF
--- a/vllm/models/qwen4_exp/nvidia/model.py
+++ b/vllm/models/qwen4_exp/nvidia/model.py
@@ -564,11 +564,14 @@ class Qwen4ExpModel(nn.Module):
         )
         # Non-persistent PLE state rebuilt in __init__; skip any ckpt
         # column for them.
-        skip_substrs = (
+        skip_substrs = [
             "hashstats_",
             "token_lookup",
             "hyper_connection_mixer.block_inject_weight",
-        )
+        ]
+        if self.hyper_connection_mixer is None:
+            # The final mixer exists only on the last pipeline stage.
+            skip_substrs.append("hyper_connection_mixer.")
         mapper = self.hf_to_vllm_mapper | WeightsMapper(
             orig_to_new_substr={substr: None for substr in skip_substrs}
         )

--- a/vllm/models/qwen4_exp/nvidia/model_state.py
+++ b/vllm/models/qwen4_exp/nvidia/model_state.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 
 from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
 from vllm.v1.worker.gpu.input_batch import InputBatch
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
@@ -26,19 +27,13 @@ class Qwen4ExpModelState(MambaHybridModelState):
     ) -> None:
         super().__init__(vllm_config, model, encoder_cache, device)
         config = self.model_config.hf_text_config
-        self.uses_ngram_embedding = bool(config.ple_layer_ids)
+        self.uses_ngram_embedding = (
+            bool(config.ple_layer_ids) and get_pp_group().is_first_rank
+        )
         if not self.uses_ngram_embedding:
             self.ngram_context_len = 0
             self.ngram_eos_token_id = 0
             return
-
-        if vllm_config.parallel_config.pipeline_parallel_size > 1:
-            raise RuntimeError(
-                "N-gram PLE embedding currently requires "
-                "pipeline_parallel_size=1 because non-first pipeline ranks do "
-                "not receive the raw input_ids required by PLE. Please run "
-                "with PP=1."
-            )
 
         self.ngram_context_len = int(config.ngram_size) - 1
         if self.ngram_context_len <= 0:

--- a/vllm/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm/models/qwen4_exp/nvidia/mtp.py
@@ -290,7 +290,11 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
         hc_count = self.hc_count
         hidden_size = self.hidden_size
 
-        if get_pp_group().is_first_rank:
+        # Native MTP is instantiated with draft PP=1 on the target
+        # model's last PP rank.  get_pp_group() still describes the target
+        # pipeline there, so accept the target hidden states as the draft's
+        # first-stage input instead of waiting for nonexistent draft tensors.
+        if get_pp_group().is_first_rank or hidden_states is not None:
             assert hidden_states is not None
             if inputs_embeds is None:
                 assert input_ids is not None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -590,7 +590,9 @@ class GPUModelRunner(
 
         # PLE
         ple_layer_ids = getattr(model_config.hf_text_config, "ple_layer_ids", ())
-        self.uses_ngram_embedding = bool(ple_layer_ids)
+        self.uses_ngram_embedding = (
+            bool(ple_layer_ids) and get_pp_group().is_first_rank
+        )
         if self.uses_ngram_embedding:
             self.ngram_context_len = int(model_config.hf_text_config.ngram_size) - 1
             self.ngram_eos_token_id = int(model_config.hf_text_config.eos_token_id)
@@ -599,13 +601,6 @@ class GPUModelRunner(
             self.ngram_eos_token_id = 0
         if self.uses_ngram_embedding and self.ngram_context_len <= 0:
             raise ValueError("N-gram embedding requires context length >= 1.")
-        if self.uses_ngram_embedding and len(get_pp_group().ranks) > 1:
-            raise RuntimeError(
-                "N-gram PLE embedding currently requires "
-                "pipeline_parallel_size=1. With PP>1, ngram context is only "
-                "injected on the first rank and can become incorrect on "
-                "non-first ranks. Please run with PP=1."
-            )
 
         self.cascade_attn_enabled = not self.model_config.disable_cascade_attn
         self.is_mm_prefix_lm = self.model_config.is_mm_prefix_lm

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -204,8 +204,18 @@ class Worker(WorkerBase):
         self._sleep_mode_backend: SleepModeBackend | None = None
 
     def _has_ple_layers(self) -> bool:
-        """Return whether this model configuration constructs PLE layers."""
+        """Return whether this pipeline stage constructs PLE layers."""
         if not envs.VLLM_PLE_CPU_OFFLOAD:
+            return False
+        parallel_config = self.parallel_config
+        pp_stride = (
+            parallel_config.prefill_context_parallel_size
+            * parallel_config.tensor_parallel_size
+        )
+        pp_rank = (
+            self.rank // pp_stride
+        ) % parallel_config.pipeline_parallel_size
+        if pp_rank != 0:
             return False
         text_config = self.model_config.hf_text_config
         return bool(getattr(text_config, "ple_layer_ids", None))
@@ -229,8 +239,6 @@ class Worker(WorkerBase):
                 f"({parallel_config.data_parallel_size_local}/"
                 f"{parallel_config.data_parallel_size} local ranks)"
             )
-        if parallel_config.pipeline_parallel_size != 1:
-            unsupported.append(f"PP={parallel_config.pipeline_parallel_size}")
         if parallel_config.prefill_context_parallel_size != 1:
             unsupported.append(f"PCP={parallel_config.prefill_context_parallel_size}")
         if parallel_config.decode_context_parallel_size != 1:


### PR DESCRIPTION
## Purpose

PP>1 currently fails for Qwen3.8-Flash-Next with PLE CPU offload, in three independent places:

1. Explicit guards reject PP (`gpu_worker._validate_ple_offload_config`, `model_state`, `gpu_model_runner`).
2. The strict weight loader raises `no module or parameter named 'hyper_connection_mixer'` on non-last PP stages (the mixer module is only constructed on the last rank, but its checkpoint columns are not skipped there).
3. Even with the community patch from #36 (morlz's `patch_qwen38_pp2.py` v4), current master fails during KV planning with:
   `ValueError: CSA+linear layer 48 cache specs violate CSA geometry` — layer 48 being the native-MTP draft layer.

This PR makes TP×PP work with PLE CPU offload **and** native MTP, and fixes the root cause of (3).

## Changes (9 hunks, 5 files)

| File | Change |
|---|---|
| `vllm/v1/worker/gpu_worker.py` | `_has_ple_layers()` becomes stage-local: only the PP rank owning the PLE layer (`layers.1.ple`) instantiates the `PleOffloadWorker`. Drop the `PP != 1` entry in `_validate_ple_offload_config`. |
| `vllm/v1/worker/gpu_model_runner.py` | n-gram context buffers and prep only exist on the first PP rank; remove the PP rejection. |
| `vllm/models/qwen4_exp/nvidia/model_state.py` | Same first-rank gating (adds `get_pp_group` import). |
| `vllm/models/qwen4_exp/nvidia/model.py` | Non-last stages skip the whole `hyper_connection_mixer.` checkpoint columns (ported from #36; without it the strict loader raises on stage 0). |
| `vllm/models/qwen4_exp/nvidia/mtp.py` | The MTP head, instantiated on the target's last PP rank, accepts the relayed target `hidden_states`. |

## Root cause of the layer-48 failure — important for #36 patch users

#36's v4 patch isolates the draft config via `cache_config=deepcopy(vllm_config.cache_config)`. That was required by the **old preview planner**, but on current master it **breaks PP+MTP**: the draft layer's KV specs are then created from a diverging CacheConfig, so `_get_kv_cache_groups_csa_linear` finds a layer-48 tuple whose geometry no longer matches the target layers and raises the error above.

On current master the **shared** `CacheConfig` is exactly what keeps the draft and target specs geometrically identical — both planner checks pass and MTP works under PP. This PR therefore deliberately does **not** carry over the deepcopy hunk. (A/B validated on hardware: with deepcopy → the geometry error; without → clean start.)

## Validation

Hardware: 4× CMP 170HX 64GB (PCIe Gen2, no P2P), AWQ W4A16 (`wtdcode/Qwen3.8-Flash-Next-AWQ-W4A16`),
`VLLM_PLE_CPU_OFFLOAD=1`, `--speculative-config '{"method":"mtp","num_speculative_tokens":3}'`,
`--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'`, warm numbers:

| Config | single-stream | prefill | 4-way aggregate |
|---|---|---|---|
| TP4 (reference) | 86.8 tok/s | 1090 tok/s | 127.6 tok/s |
| TP2×PP2 (this PR) | 87.7 tok/s | 1159 tok/s | 136.8 tok/s |
| TP1×PP4 + async-scheduling (this PR) | 82.0 tok/s | 2011 tok/s | 199.8 tok/s |

- TP1×PP4 + async + `--max-num-seqs 32` + 1M context (YaRN): 32-way concurrency, **787 tok/s aggregate**.
- Correctness with MTP relayed draft tokens crossing the stage boundary: math answer exact, 21k-token needle retrieved verbatim, `qwen3_xml` tool calls well-formed, MTP acceptance ~0.74.

## Notes

- The 9 hunks were developed as a standalone patcher (idempotent, fails loudly on source drift) and applied to current master; the only master drift vs the v0.11.1 files is unrelated to the touched regions.
- Related: #36 (community PP patch this ports and fixes), #53896 (upstream model support — its latest branch replaces the CSA planner entirely, which would make this PR obsolete after a rebase; until then this enables PP on the current tree).
