### PR TITLE
fix(mtp): fix GLM-5.3 MTP-3 crash from padded seq_lens copy and Kpool…

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -1504,8 +1504,12 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     seq_lens //= self.compress_ratio
                 else:
                     # Copy to avoid mutating shared state; keeps CG address stable.
+                    # MTP warmup pads seq_lens beyond the active requests, so
+                    # seq_lens can hold num_decode_tokens rows while the
+                    # destination slice above only wants the active decode
+                    # rows; slicing the source keeps padding rows zeroed.
                     self.expanded_seq_lens_buffer[:num_decodes] = (
-                        seq_lens // self.compress_ratio
+                        seq_lens[:num_decodes] // self.compress_ratio
                     )
                     self.expanded_seq_lens_buffer[num_decodes:num_decode_tokens] = 0
                     seq_lens = self.expanded_seq_lens_buffer[:num_decode_tokens]

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -68,6 +68,7 @@ from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     CircularBufferSpec,
     KVCacheConfig,
+    KpoolTailSpec,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -631,7 +632,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             layer_spec = (
                 spec.first_spec if isinstance(spec, UniformTypeKVCacheSpecs) else spec
             )
-            slot_mapping_enabled.append(not isinstance(layer_spec, CircularBufferSpec))
+            # KpoolTailSpec has its own ring-buffer slot mapping
+            # (KpoolTailMetadataBuilder); feeding it into the generic
+            # position-indexed slot mapping reads far beyond its 1-block
+            # table row (e.g. pos 130559 // 4 = 32639 vs stride 32) and
+            # crashes with a CUDA illegal memory access on GLM-5.3-Flash.
+            slot_mapping_enabled.append(
+                not isinstance(layer_spec, (CircularBufferSpec, KpoolTailSpec))
+            )
             # Let each cache type account for CP. Attention KV is DCP-sharded,
             # while Mamba/GDN recurrent state is replicated across DCP ranks.
             max_num_blocks = spec.max_num_blocks_per_req(


### PR DESCRIPTION
## Purpose

Fix two crashes that block running **GLM-5.3-Flash-AWQ with MTP** (`num_speculative_tokens=3`) on 8x RTX 4090 (sm89, `TRITON_MLA_SPARSE` backend, fp8 indexer KV cache, TP8+EP8, `--mamba-cache-mode align`):

1. **MTP-3 warmup crash** (`vllm/v1/attention/backends/mla/indexer.py`):

```
RuntimeError: The expanded size of the tensor (118) must match the existing size (128) at non-singleton dimension 0.
  at DeepseekV32IndexerMetadataBuilder.build (v1/attention/backends/mla/indexer.py:1507)
```

In MTP-3 warmup the draft decode batch is token-padded: `num_decodes=118` requests but `seq_lens` holds `num_decode_tokens=128` rows. The non-buffer-view `compress_ratio > 1` branch assigned the full padded source into a `num_decodes`-sized destination slice.

**Fix**: slice the source to the active decode rows; the next line already zeroes the graph-padding rows, which matches the surrounding invariant and keeps CUDA graph replay safe:

```python
self.expanded_seq_lens_buffer[:num_decodes] = (
    seq_lens[:num_decodes] // self.compress_ratio
)
self.expanded_seq_lens_buffer[num_decodes:num_decode_tokens] = 0
```

Note: the tempting "expand the destination to `num_decode_tokens`" workaround starts fine but silently turns padding rows into valid-looking context lengths — do not do that.

2. **Runtime CUDA illegal memory access on long conversations** (`vllm/v1/worker/gpu/model_runner.py`):

```
RuntimeError: Triton Error [CUDA]: an illegal memory access
  at _compute_slot_mappings_kernel (v1/worker/gpu/block_table.py:204)
```

The `KpoolTailSpec` KV group holds a fixed 1-block-per-request ring buffer (`block_size=4`, block-table row width 32). It was not excluded from the generic position-indexed slot mapping, so the kernel computed `block_indices = position // kernel_block_size` and read `block_table[request][32639]` when the conversation reached position 130559 (126720 computed + 3840 scheduled) — far beyond the 32-column row.

The original check only excluded `CircularBufferSpec`; `KpoolTailSpec` (a `SlidingWindowSpec` subclass) slipped through. `KpoolTailSpec` already has its own dedicated mapping (`KpoolTailMetadataBuilder.compute_kpool_tail_slot_mapping`), so the generic slot mapping must be disabled for it, the same way `CircularBufferSpec` is excluded:

```python
slot_mapping_enabled.append(
    not isinstance(layer_spec, (CircularBufferSpec, KpoolTailSpec))
)
```

Both code paths are unchanged in upstream vLLM `main`, so this PR applies there as well.

## Test Plan

On 8x RTX 4090 48G (sm89), serve `wtdcode/GLM-5.3-Flash-AWQ-W4A16` with:

```bash
vllm serve /data/models/GLM-5.3-Flash-AWQ-W4A16 \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3}' \
  --tensor-parallel-size 8 --enable-expert-parallel \
  --dtype bfloat16 --kv-cache-dtype auto \
  --max-model-len 409600 \
  --kv-cache-memory 17716740096 \
  --max-num-batched-tokens 4096 \
  --enable-prefix-caching --mamba-cache-mode align \
  --tool-call-parser glm47 --reasoning-parser glm47 \
  --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1,2,4,8],"max_cudagraph_capture_size":8}' \
  --port 18080
```

Then verify: engine warmup, basic chat, a plain ~131k prompt crossing the 130560 boundary, multi-turn tool-call conversations (long system prompt + `assistant.tool_calls` / `tool` results + model-switch continuation) crossing 130560, and 8-way concurrent mixed requests.

Note: at ~305k context the sparse indexer Triton fp8 MQA logits fallback allocates a transient `(M, N)` fp32 logits buffer (422 MiB/GPU); an explicit `--kv-cache-memory` (16.5–17.7 GiB per 48G GPU verified) is required instead of `gpu-memory-utilization=0.95`, which left only ~406 MiB free and OOMed. This part is deployment config, not a code change.

## Test Result

- **Before**: MTP-3 dies at warmup with the 118 vs 128 expand error; with only a shape-bypass it starts but a real long coding-agent conversation (~126k cached prefix continued to ~130560) deterministically crashes all 8 TP workers with an illegal memory access; the same reproduces on a plain 131k prompt (131,483 tokens) crossing the 130560 boundary.
- **After both fixes**: warmup, basic chat, 131k prompt, long tool-call conversations crossing 130560, and 8-way concurrent mixed requests all pass with MTP-3 active — mean acceptance length up to **3.69**, per-position acceptance up to **0.97 / 0.90 / 0.83**, and a 305k-token prompt (304,540 tokens) completes with no OOM.
- Debugging notes: the asynchronous stacks (GDN `compute_causal_conv1d_metadata -> pin_memory()`, NCCL, KV block zeroing) are misleading; with `CUDA_LAUNCH_BLOCKING=1` the crash deterministically lands in `_compute_slot_mappings_kernel`, and HTTP-reported instrumentation of `compute_slot_mappings()` inputs (`block_table_strides=[6400,32,643,643,643]`, `positions_max=130559`) proved the 32 vs 32639 out-of-range read arithmetically.

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
