### PR TITLE
fix(spec-decode): load draft token embedding from checkpoint under PP

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+import logging
+import os
+
 import torch
 import torch.nn as nn
 
@@ -7,6 +11,72 @@ from vllm.config import CompilationMode, VllmConfig, replace
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.lora.layers.base import BaseLayerWithLoRA
 from vllm.model_executor.model_loader import get_model
+
+logger = logging.getLogger(__name__)
+
+# Candidate checkpoint keys for the token embedding, most specific first.
+# GLM5-Next multimodal checkpoints prefix the text tower weights.
+_EMBED_KEYS = (
+    "model.language_model.embed_tokens.weight",
+    "model.embed_tokens.weight",
+    "model.embed.weight",
+    "embed_tokens.weight",
+)
+
+
+def _has_real_weight(module) -> bool:
+    """True for a materialised layer; False for PPMissingLayer / None.
+
+    Under pipeline parallelism vLLM replaces the layers a rank does not own with
+    PPMissingLayer, which has no ``weight``. Aliasing one of those into the draft
+    silently produces a no-op layer rather than an error, so check explicitly.
+    """
+    return module is not None and getattr(module, "weight", None) is not None
+
+
+def _load_embed_from_checkpoint(embed: nn.Module, model_path: str) -> None:
+    """Fill the draft's own token embedding straight from the checkpoint.
+
+    Only needed under PP: the drafter runs on the LAST pipeline rank, but the
+    target's ``embed_tokens`` lives on the FIRST, so there is nothing local to
+    alias. The MTP ``load_weights()`` only consumes spec-layer tensors (the
+    top-level ``embed_tokens`` key is skipped by the spec-layer filter), so the
+    draft's own embedding would otherwise stay uninitialised memory -- the draft
+    then emits constant garbage tokens (acceptance ~= 1). Reading the one tensor
+    off disk avoids adding a cross-rank collective. Mirrors the dspark+PP fix.
+    """
+    from safetensors import safe_open
+
+    model_path = os.path.expanduser(model_path)
+    index_path = os.path.join(model_path, "model.safetensors.index.json")
+    key = shard = None
+    if os.path.exists(index_path):
+        with open(index_path) as f:
+            weight_map = json.load(f)["weight_map"]
+        for cand in _EMBED_KEYS:
+            if cand in weight_map:
+                key, shard = cand, os.path.join(model_path, weight_map[cand])
+                break
+    if key is None:
+        raise RuntimeError(
+            f"PP spec-decode: could not find a token-embedding tensor in "
+            f"{index_path}; looked for {_EMBED_KEYS}. The draft needs its own "
+            "copy because the target's embedding lives on PP rank 0."
+        )
+
+    with safe_open(shard, framework="pt") as f:
+        w = f.get_tensor(key)
+    with torch.no_grad():
+        # VocabParallelEmbedding pads the vocab dimension, so copy into the
+        # leading rows rather than assigning the whole tensor.
+        embed.weight.data[: w.shape[0]].copy_(
+            w.to(dtype=embed.weight.dtype, device=embed.weight.device)
+        )
+    logger.info(
+        "PP spec-decode: loaded draft token embedding %s from key %r",
+        tuple(w.shape),
+        key,
+    )
 
 
 def _should_share(eagle: nn.Module, flag: str, draft, target) -> bool:
@@ -79,25 +149,33 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
     target_inner = target_language_model.model
     draft_inner = eagle_model.model
 
-    # Skip embedding sharing under PP — each rank owns its own embedding.
-    if get_pp_group().world_size == 1:
-        target_embed = getattr(target_inner, "embed_tokens", None) or getattr(
-            target_inner, "embedding", None
-        )
-        # If the target's embedding is LoRA-wrapped, share the underlying base
-        # layer. The draft is not part of the LoRA adapter; sharing the wrapper
-        # would make the draft run the LoRA embedding kernel with the target's
-        # punica metadata (sized for the target's token count), causing an
-        # out-of-bounds GPU access during multi-step draft decode.
-        if isinstance(target_embed, BaseLayerWithLoRA):
-            target_embed = target_embed.base_layer
-        draft_embed = getattr(draft_inner, "embed_tokens", None)
-        if target_embed is not None and _should_share(
-            eagle_model, "has_own_embed_tokens", draft_embed, target_embed
-        ):
-            if draft_embed is not None:
-                del draft_inner.embed_tokens
-            draft_inner.embed_tokens = target_embed
+    # Embedding sharing: only possible when the target's embed_tokens is
+    # materialised on this rank (under PP it lives on rank 0, and the drafter
+    # runs on the LAST rank, where the target is a PPMissingLayer).
+    target_embed = getattr(target_inner, "embed_tokens", None) or getattr(
+        target_inner, "embedding", None
+    )
+    # If the target's embedding is LoRA-wrapped, share the underlying base
+    # layer. The draft is not part of the LoRA adapter; sharing the wrapper
+    # would make the draft run the LoRA embedding kernel with the target's
+    # punica metadata (sized for the target's token count), causing an
+    # out-of-bounds GPU access during multi-step draft decode.
+    if isinstance(target_embed, BaseLayerWithLoRA):
+        target_embed = target_embed.base_layer
+    draft_embed = getattr(draft_inner, "embed_tokens", None)
+    if _has_real_weight(target_embed) and _should_share(
+        eagle_model, "has_own_embed_tokens", draft_embed, target_embed
+    ):
+        if draft_embed is not None:
+            del draft_inner.embed_tokens
+        draft_inner.embed_tokens = target_embed
+    elif get_pp_group().world_size != 1 and draft_embed is not None:
+        # PP: the target's embedding is a PPMissingLayer here. Keep the
+        # draft's own module and populate it from the checkpoint -- the MTP
+        # load_weights() filters out every non-spec-layer key, so its own
+        # embed_tokens would otherwise stay uninitialised and the draft would
+        # emit constant garbage tokens (acceptance ~= 1, corrupt output).
+        _load_embed_from_checkpoint(draft_embed, draft_model_config.model)
 
     target_lm_head = get_target_lm_head(target_model, target_language_model)
     draft_lm_head = getattr(eagle_model, "lm_head", None)


### PR DESCRIPTION
## Problem

Under pipeline parallelism the spec-decode drafter runs on the **last** PP rank while the target's `embed_tokens` lives on the **first** rank — so there is nothing local to alias into the draft. Compounding this, MTP's `load_weights()` filters out every non-spec-layer key (including the top-level `embed_tokens`), so the draft's *own* embedding stays **uninitialised GPU memory**. The draft then emits near-constant garbage tokens: acceptance ≈ 1, and MTP+PP silently degrades to pure target decode (or worse).

Current code skips embedding sharing wholesale whenever `pp world_size != 1`, so this configuration has no correct path.

## Fix

- Share the target embedding when it is actually materialised on this rank. A `_has_real_weight` guard prevents aliasing a `PPMissingLayer` (which has no `.weight` and would silently become a no-op layer).
- Otherwise (PP, drafter on last rank): populate the draft's own embedding by reading the single tensor straight from the checkpoint via `model.safetensors.index.json` (candidate keys cover GLM5-Next's language-model prefix). No cross-rank collective needed; one-time load cost.

Verified on 4× sm_80 64 GB (PCIe, no P2P), GLM-5.3-Flash AWQ W4A16, `PP4 14,12,12,7` + `--speculative-config {"method":"mtp","num_speculative_tokens":5}`:

| | before | after |
|---|---|---|
| draft acceptance | ~1 token | mean length 3.3–3.8 |
| acceptance rate | ≈0% | 46–56% |
| correctness battery (temp 0) | — | 9/9 |

Same shape also validated with DSpark (PP4 + DSpark5: acceptance length 3.11, 42.3%), so the fix generalises beyond EAGLE-style MTP.
