### PR TITLE
fix(glm5next): skip PP-missing layers in FP8 dequant load helpers

### DIFF
--- a/tests/models/test_glm5next_fp8_pp_load.py
+++ b/tests/models/test_glm5next_fp8_pp_load.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""PP-missing layers must be skipped by the glm5next FP8 dequant load helpers.
+
+With pipeline parallelism every rank iterates the full checkpoint; layers not
+held by this rank have no parameters, so the helpers must not buffer them or
+look their params up.
+"""
+
+import torch
+
+from vllm.models.glm5next.nvidia.model import (
+    _try_load_fp8_attn_proj,
+    _try_load_fp8_indexer_wk,
+)
+
+PP_MISSING = ["model.layers.0."]
+
+
+class _ParamStub:
+    def __init__(self):
+        self.calls = []
+
+    def weight_loader(self, param, weight, *args):
+        self.calls.append((weight, args))
+
+
+def _fp8_pair(name_prefix):
+    weight = torch.full((128, 128), 1.0, dtype=torch.float8_e4m3fn)
+    scale = torch.ones(1, 1)
+    return (
+        (f"{name_prefix}.weight", weight),
+        (f"{name_prefix}.weight_scale_inv", scale),
+    )
+
+
+def test_indexer_wk_skips_pp_missing_layer():
+    params_dict: dict = {}  # layer lives on another PP rank
+    buf, loaded = {}, set()
+    (w_name, w), (s_name, s) = _fp8_pair("model.layers.0.self_attn.indexer.wk")
+
+    assert _try_load_fp8_indexer_wk(w_name, w, buf, params_dict, loaded, PP_MISSING)
+    assert _try_load_fp8_indexer_wk(s_name, s, buf, params_dict, loaded, PP_MISSING)
+    assert buf == {}
+    assert loaded == set()
+
+
+def test_indexer_wk_dequantizes_owned_layer():
+    param = _ParamStub()
+    params_dict = {"model.layers.1.self_attn.indexer.wk_weights_proj.weight": param}
+    buf, loaded = {}, set()
+    (w_name, w), (s_name, s) = _fp8_pair("model.layers.1.self_attn.indexer.wk")
+
+    assert _try_load_fp8_indexer_wk(w_name, w, buf, params_dict, loaded, [])
+    assert _try_load_fp8_indexer_wk(s_name, s, buf, params_dict, loaded, [])
+    [(weight, args)] = param.calls
+    assert args == (0,)
+    assert weight.dtype == torch.bfloat16
+    assert weight.shape == (128, 128)
+    assert "model.layers.1.self_attn.indexer.wk_weights_proj.weight" in loaded
+
+
+def test_attn_proj_skips_pp_missing_layer():
+    params_dict: dict = {}
+    buf, loaded = {}, set()
+    (w_name, w), (s_name, s) = _fp8_pair("model.layers.0.self_attn.q_a_proj")
+
+    assert _try_load_fp8_attn_proj(w_name, w, buf, params_dict, loaded, 0, PP_MISSING)
+    assert _try_load_fp8_attn_proj(s_name, s, buf, params_dict, loaded, 0, PP_MISSING)
+    assert buf == {}
+    assert loaded == set()
+
+
+def test_attn_proj_dequantizes_owned_layer():
+    param = _ParamStub()
+    params_dict = {"model.layers.1.self_attn.fused_qkv_a_proj.weight": param}
+    buf, loaded = {}, set()
+    (w_name, w), (s_name, s) = _fp8_pair("model.layers.1.self_attn.q_a_proj")
+
+    assert _try_load_fp8_attn_proj(w_name, w, buf, params_dict, loaded, 0, [])
+    assert _try_load_fp8_attn_proj(s_name, s, buf, params_dict, loaded, 0, [])
+    [(weight, args)] = param.calls
+    assert args == (0,)
+    assert weight.dtype == torch.bfloat16
+    assert weight.shape == (128, 128)
+    assert "model.layers.1.self_attn.fused_qkv_a_proj.weight" in loaded

--- a/vllm/models/glm5next/nvidia/model.py
+++ b/vllm/models/glm5next/nvidia/model.py
@@ -68,6 +68,7 @@ from vllm.model_executor.models.interfaces import (
 from vllm.model_executor.models.utils import (
     AutoWeightsLoader,
     PPMissingLayer,
+    get_pp_missing_layer_names,
     init_vllm_registered_model,
     is_pp_missing_parameter,
     make_layers,
@@ -768,6 +769,7 @@ class Glm5NextModel(nn.Module):
             expert_params_mapping = []
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        pp_missing_layer_names = get_pp_missing_layer_names(self)
 
         # GLM-5.3-Flash NoPE checkpoints omit the RoPE rows from
         # ``kv_a_proj_with_mqa``; pad them with zeros for the model shape.
@@ -799,6 +801,7 @@ class Glm5NextModel(nn.Module):
                 _pending_wk_fp8,
                 params_dict,
                 loaded_params,
+                pp_missing_layer_names,
             ):
                 continue
 
@@ -811,6 +814,7 @@ class Glm5NextModel(nn.Module):
                 params_dict,
                 loaded_params,
                 kv_a_pad_size,
+                pp_missing_layer_names,
             ):
                 continue
 
@@ -1104,7 +1108,9 @@ def get_spec_layer_idx_from_weight_name(
     return None
 
 
-def _try_load_fp8_indexer_wk(name, tensor, buf, params_dict, loaded_params):
+def _try_load_fp8_indexer_wk(
+    name, tensor, buf, params_dict, loaded_params, pp_missing_layer_names
+):
     if "indexer.wk." not in name or "wk_weights" in name:
         return False
     is_weight = name.endswith(".weight") and tensor.dtype == torch.float8_e4m3fn
@@ -1112,6 +1118,11 @@ def _try_load_fp8_indexer_wk(name, tensor, buf, params_dict, loaded_params):
     if not is_weight and not is_scale:
         return False
     layer_prefix = name.rsplit(".wk.", 1)[0]
+    if any(
+        name.startswith(missing_layer_name)
+        for missing_layer_name in pp_missing_layer_names
+    ):
+        return True
     entry = buf.setdefault(layer_prefix, {})
     entry["weight" if is_weight else "scale"] = tensor
     if "weight" not in entry or "scale" not in entry:
@@ -1178,6 +1189,7 @@ def _try_load_fp8_attn_proj(
     params_dict,
     loaded_params,
     kv_a_pad_size: int,
+    pp_missing_layer_names,
 ) -> bool:
     """Dequantize FP8 q_a_proj / kv_a_proj_with_mqa / o_proj to BF16 on load.
 
@@ -1200,6 +1212,11 @@ def _try_load_fp8_attn_proj(
     is_scale = "weight_scale_inv" in name
     if not is_weight and not is_scale:
         return False
+    if any(
+        name.startswith(missing_layer_name)
+        for missing_layer_name in pp_missing_layer_names
+    ):
+        return True
 
     layer_prefix = name.rsplit(suffix, 1)[0]
     target_w = f"{layer_prefix}.{target_base}.weight"

--- a/vllm/models/glm5next/nvidia/mtp.py
+++ b/vllm/models/glm5next/nvidia/mtp.py
@@ -21,7 +21,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.models.deepseek_mtp import SharedHead
 from vllm.model_executor.models.deepseek_v2 import DeepseekV2MixtureOfExperts
-from vllm.model_executor.models.utils import maybe_prefix
+from vllm.model_executor.models.utils import get_pp_missing_layer_names, maybe_prefix
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
@@ -307,6 +307,7 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        pp_missing_layer_names = get_pp_missing_layer_names(self)
         _pending_wk_fp8: dict = {}
         # GLM-5.3-Flash NoPE checkpoints omit the RoPE rows from
         # ``kv_a_proj_with_mqa``; the FP8-to-BF16 path pads them for the model.
@@ -333,6 +334,7 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
                 _pending_wk_fp8,
                 params_dict,
                 loaded_params,
+                pp_missing_layer_names,
             ):
                 continue
 
@@ -348,6 +350,7 @@ class Glm5NextMTP(nn.Module, DeepseekV2MixtureOfExperts):
                 params_dict,
                 loaded_params,
                 kv_a_pad_size,
+                pp_missing_layer_names,
             ):
                 continue
 


### PR DESCRIPTION
## Description

Fixes a crash when loading a GLM-5.3-Flash block-FP8 checkpoint with `--pipeline-parallel-size > 1` (e.g. TP=4 + PP=2).

With PP, every rank iterates the full checkpoint and layers held by other stages are built as `PPMissingLayer` (no parameters). The normal load paths in `Glm5NextModel.load_weights` guard with `is_pp_missing_parameter`, but the two FP8 dequant helpers added for glm5next lacked this protection:

- `_try_load_fp8_indexer_wk`: crashed with `KeyError` at `params_dict[fused_name]` (`wk_weights_proj` param does not exist on this rank).
- `_try_load_fp8_attn_proj`: the `if target_s in params_dict: return False` guard passes for missing layers (the whole layer is absent), then crashed with `KeyError` at `params_dict[target_w]`.

The fix mirrors the existing pattern in `deepseek_v2.py` (`_try_load_fp8_indexer_wk` there already takes `pp_missing_layer_names`): collect `get_pp_missing_layer_names(self)` once per `load_weights` and skip matching weights before buffering. `mtp.py` callers are updated for the new signature (the MTP model builds all layers, so the list is empty there and behavior is unchanged).

## Not a duplicate

- Open PRs in this repo: only 2 dependabot dependency bumps (#54, #55) — unrelated.
- Upstream `vllm-project/vllm` does not contain `vllm/models/glm5next/` (fork-specific code), so there is no upstream PR to backport from.

## Testing

- New unit tests: `tests/models/test_glm5next_fp8_pp_load.py` — verifies both helpers skip PP-missing layers (no `KeyError`, nothing buffered) and still dequantize + load owned layers correctly.
- Commands run:
  - `python -m py_compile vllm/models/glm5next/nvidia/model.py vllm/models/glm5next/nvidia/mtp.py tests/models/test_glm5next_fp8_pp_load.py` — pass
  - `ruff check` / `ruff format` on the three touched files — pass
  - `pytest tests/models/test_glm5next_fp8_pp_load.py` — to be run before merge (environment install was interrupted; submitter will confirm results here)
- Reproduction of the original failure: loading with `--tensor-parallel-size 4 --pipeline-parallel-size 2` on a block-FP8 GLM-5.3-Flash checkpoint previously raised `KeyError` during weight load; with this change the missing-layer weights are skipped like every other path.

## AI assistance

This change was developed with AI assistance (ZCode). The submitting human has reviewed every changed line and is responsible for running the tests above before merge.
