### PR TITLE
[Bugfix] PP + MTP + prefix caching corrupted mamba recurrent state (Qwen3.8 "duct" loops)

### DIFF
--- a/tests/kernels/mamba/test_precopy_mamba_align.py
+++ b/tests/kernels/mamba/test_precopy_mamba_align.py
@@ -31,7 +31,11 @@ import torch
 from vllm.model_executor.layers.mamba import mamba_utils as layer_mamba_utils
 from vllm.platforms import current_platform
 from vllm.v1.worker import mamba_utils as worker_mamba_utils
-from vllm.v1.worker.mamba_utils import _TEMPORAL_TILES, precopy_mamba_align_fused_kernel
+from vllm.v1.worker.mamba_utils import (
+    _TEMPORAL_TILES,
+    postprocess_mamba_fused_kernel,
+    precopy_mamba_align_fused_kernel,
+)
 
 _parametrize: Callable[..., Callable[[Any], Any]]
 
@@ -418,6 +422,195 @@ def test_preprocess_fused_align_matches_scalar_bookkeeping(monkeypatch, token_bi
     assert fused_copy_calls == scalar_copy_calls
 
 
+# Batch order -> request-state slot, deliberately NOT the identity.
+_PERM = (2, 0, 3, 1)
+
+
+def _build_disjoint_block_table(num_reqs, device):
+    """[num_reqs, MAX_COLS] where every row owns ids no other row references."""
+    num_blocks = num_reqs * MAX_COLS + 1
+    bt = torch.empty(num_reqs, MAX_COLS, dtype=torch.int32, device=device)
+    for r in range(num_reqs):
+        bt[r] = torch.arange(
+            1 + r * MAX_COLS, 1 + (r + 1) * MAX_COLS, dtype=torch.int32, device=device
+        )
+    return bt, num_blocks
+
+
+def _assert_copies_landed(convs, ssms, conv_ref, ssm_ref):
+    for layer in range(NUM_LAYERS):
+        torch.testing.assert_close(convs[layer], conv_ref[layer], rtol=0, atol=0)
+        torch.testing.assert_close(ssms[layer], ssm_ref[layer], rtol=0, atol=0)
+
+
+@_parametrize("conv_state_dim_first", [False, True])
+@_cuda_required
+def test_precopy_indexes_block_tables_by_req_slot(conv_state_dim_first):
+    """Block-table ROW ATTRIBUTION under a permuted ``idx_mapping``.
+
+    The tables handed to the align copy kernels are the persistent
+    per-request-slot tables (row = request-state slot, written by
+    ``BlockTables.append_block_ids(req_index, ...)``), while the grid runs in
+    batch order and ``idx_mapping`` resolves batch row -> slot. The equivalence
+    test above only ever launches with an identity mapping, where indexing rows
+    by batch row and by request slot are indistinguishable -- so it cannot see a
+    regression on this axis.
+
+    It matters: under pipeline parallelism a non-last rank runs its postprocess
+    ``pp_size`` steps late, so the batch mapping it holds is stale. Indexing the
+    source tables by batch row then walks *another request's* block ids -- freed
+    or reallocated ones -- and on a hybrid model whose unified cache layout
+    aliases every cache tensor inside one page, that silently poisons live
+    recurrent state (all-NaN logits, constant-token output) or faults outright.
+    """
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    num_reqs = len(_PERM)
+    bt, num_blocks = _build_disjoint_block_table(num_reqs, device)
+
+    # Per-slot decisions must DIFFER, or the permutation is invisible: with an
+    # identity-shaped setup every batch row performs the same copy, so reading
+    # row ``batch_idx`` instead of row ``req_idx`` still touches the right bytes
+    # in aggregate. Here only slots 0 and 3 copy, and each row owns disjoint
+    # block ids, so a row mix-up moves state onto a different physical block.
+    #   slot 0: col 1 -> col 0, bias 0            (copy)
+    #   slot 1: src_col == dst_col                (no boundary, skip)
+    #   slot 2: src_col < 0                       (fresh, skip)
+    #   slot 3: col 2 -> col 0, bias 1            (copy, accepted-token shift)
+    src_col = torch.tensor([1, 1, -1, 2], dtype=torch.int32, device=device)
+    dst_col = torch.tensor([0, 1, 0, 0], dtype=torch.int32, device=device)
+    bias = torch.tensor([0, 0, 0, 1], dtype=torch.int32, device=device)
+
+    convs, ssms = _build_state(num_blocks, device, conv_state_dim_first)
+    conv_ref, ssm_ref = _reference(
+        convs,
+        ssms,
+        bt.cpu(),
+        src_col.cpu(),
+        dst_col.cpu(),
+        bias.cpu(),
+        num_reqs,
+        conv_state_dim_first,
+    )
+    base, blk_stride, elem, inner, width, group, drc, drs = _build_meta(
+        convs, ssms, device, conv_state_dim_first
+    )
+    bt_ptrs = torch.tensor([bt.data_ptr()], dtype=torch.int64, device=device)
+    idx_mapping = torch.tensor(_PERM, dtype=torch.int32, device=device)
+
+    precopy_mamba_align_fused_kernel[(num_reqs, NUM_LAYERS * 2, 1)](
+        dst_col,
+        src_col,
+        bias,
+        bt_ptrs,
+        bt.stride(0),
+        base,
+        blk_stride,
+        elem,
+        inner,
+        width,
+        group,
+        drc,
+        drs,
+        idx_mapping,
+        num_reqs,
+        COPY_BLOCK_SIZE=1024,
+        CONV_STATE_DIM_FIRST=conv_state_dim_first,
+        HAS_IDX_MAPPING=True,
+        TEMPORAL_TILES=1,
+    )
+    torch.accelerator.synchronize()
+    _assert_copies_landed(convs, ssms, conv_ref, ssm_ref)
+
+
+@_parametrize("conv_state_dim_first", [False, True])
+@_cuda_required
+def test_postprocess_indexes_block_tables_by_req_slot(conv_state_dim_first):
+    """Same row-attribution invariant for ``postprocess_mamba_fused_kernel``.
+
+    The two kernels share ``_copy_mamba_state_block``, and the postprocess one is
+    the deferred-under-PP path where the stale batch mapping actually bites.
+    Decision inputs are chosen so every slot copies col 1 -> col 0 with zero
+    accepted-token bias: ``num_computed + num_scheduled - num_draft ==
+    block_size`` makes the aligned position equal the running-state count, so
+    ``needs_copy`` holds, ``accept_token_bias`` is 0 and ``dest_block_idx`` is 0.
+    """
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    num_reqs = len(_PERM)
+    block_size = 8
+    bt, num_blocks = _build_disjoint_block_table(num_reqs, device)
+
+    # Per-slot decisions differ (see the precopy test for why that is required).
+    # With num_scheduled = num_draft = 1, num_accepted = 1:
+    #   num_tokens_running_state = num_computed, new_num_computed = same,
+    #   aligned = floor(num_computed / block_size) * block_size.
+    #   slot 0: computed 8 -> aligned 8, bias 0, dest 0, src 1   (copy)
+    #   slot 1: computed 8 -> dest 0 == src 0, bias 0            (skip)
+    #   slot 2: computed 5 -> aligned 0 < 5, needs_copy false    (skip)
+    #   slot 3: computed 7 + accepted 2 -> aligned 8, bias 1,
+    #           dest 0, src 2                                    (copy)
+    num_accepted = torch.tensor([1, 1, 1, 2], dtype=torch.int32, device=device)
+    state_idx = torch.tensor([1, 0, 1, 2], dtype=torch.int32, device=device)
+    num_scheduled = torch.ones(num_reqs, dtype=torch.int32, device=device)
+    num_computed = torch.tensor([8, 8, 5, 7], dtype=torch.int32, device=device)
+    num_draft = torch.ones(num_reqs, dtype=torch.int32, device=device)
+    num_accepted_out = num_accepted.clone()
+
+    # What a correct kernel must do, stated directly: slots 0 and 3 copy; slot 2
+    # is marked fresh here because its skip comes from ``needs_copy``, which the
+    # reference models through the src_col < 0 branch.
+    ref_src = torch.tensor([1, 0, -1, 2], dtype=torch.int32)
+    ref_dst = torch.zeros(num_reqs, dtype=torch.int32)
+    ref_bias = torch.tensor([0, 0, 0, 1], dtype=torch.int32)
+
+    convs, ssms = _build_state(num_blocks, device, conv_state_dim_first)
+    conv_ref, ssm_ref = _reference(
+        convs,
+        ssms,
+        bt.cpu(),
+        ref_src,
+        ref_dst,
+        ref_bias,
+        num_reqs,
+        conv_state_dim_first,
+    )
+    base, blk_stride, elem, inner, width, group, drc, drs = _build_meta(
+        convs, ssms, device, conv_state_dim_first
+    )
+    bt_ptrs = torch.tensor([bt.data_ptr()], dtype=torch.int64, device=device)
+    idx_mapping = torch.tensor(_PERM, dtype=torch.int32, device=device)
+
+    postprocess_mamba_fused_kernel[(num_reqs, NUM_LAYERS * 2, 1)](
+        num_accepted,
+        state_idx,
+        num_scheduled,
+        num_computed,
+        num_draft,
+        bt_ptrs,
+        bt.stride(0),
+        base,
+        blk_stride,
+        elem,
+        inner,
+        width,
+        group,
+        drc,
+        drs,
+        num_accepted_out,
+        idx_mapping,
+        num_reqs,
+        block_size=block_size,
+        COPY_BLOCK_SIZE=1024,
+        CONV_STATE_DIM_FIRST=conv_state_dim_first,
+        HAS_IDX_MAPPING=True,
+        PRECOMPUTED_NEW_COMPUTED=False,
+        TEMPORAL_TILES=1,
+    )
+    torch.accelerator.synchronize()
+    _assert_copies_landed(convs, ssms, conv_ref, ssm_ref)
+
+
 if __name__ == "__main__":
     from itertools import product
 
@@ -434,3 +627,7 @@ if __name__ == "__main__":
             f"OK num_reqs={nr} token_bias={tb} has_idx_mapping={mapping} "
             f"conv_dim_first={dim_first} temporal_tiles={tt}"
         )
+    for dim_first in (False, True):
+        test_precopy_indexes_block_tables_by_req_slot(dim_first)
+        test_postprocess_indexes_block_tables_by_req_slot(dim_first)
+        print(f"OK row attribution conv_dim_first={dim_first}")

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1544,6 +1544,17 @@ class MambaManager(SingleTypeKVCacheManager):
         )
         assert dcp_world_size == 1, "DCP not support mamba now."
         assert pcp_world_size == 1, "PCP not support mamba now."
+        if drop_eagle_block:
+            # EAGLE/MTP requires dropping the final matched page of a hit: its
+            # recurrent-state snapshot may have been taken over draft tokens
+            # that verification later rejected, so resuming from it seeds the
+            # GDN/PLE state with state from a sequence that was never committed
+            # (vllm#48375, unmerged upstream). Upstream lowers max_num_blocks by
+            # one; lowering max_length by one mamba block is arithmetically
+            # identical for the coarse loop below ((x - b) // b == x // b - 1)
+            # and ALSO bounds the fine-grained partial-unit branch, which
+            # upstream's diff predates.
+            max_length = max(0, max_length - kv_cache_spec.block_size)
         block_hashes = resolve_block_hashes(
             block_hashes,
             block_pool.hash_block_size,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -1694,9 +1694,17 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             # boundaries before the forward. Runs only on real batches, and
             # before model_state.prepare_attn gathers num_accepted_tokens so the
             # boundary reset is visible to the attention metadata.
+            #
+            # Pass the SOURCE per-request-slot block tables, not the per-step
+            # gathered views: the mamba spec-decode context captures these
+            # tensors' raw data_ptrs exactly once and its copy kernels index rows
+            # by req_idx (mamba_utils.py). Gathered views are batch-ordered and
+            # are re-gathered every step, so under PP (max_concurrent_batches =
+            # pp_size + 1) a deferred postprocess on a non-last rank would walk
+            # another step's batch mapping through freed/reallocated block ids.
             self.model_state.preprocess_state(
                 input_batch,
-                block_tables,
+                tuple(bt.gpu for bt in self.block_tables.block_tables),
                 self.kv_cache_config,
                 self.req_states.num_computed_tokens.gpu,
             )

--- a/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
+++ b/vllm/v1/worker/gpu/model_states/mamba_hybrid.py
@@ -118,8 +118,22 @@ class MambaHybridModelState(DefaultModelState):
         self.num_accepted_tokens_gpu[req_index].fill_(1)
         if self._align_mode:
             # Seed the running state block from the resumed/prefilled position.
+            # The divisor must be the MAMBA group's block size, not the
+            # attention/CLI block size: on hybrids they differ (here 1616 vs the
+            # mamba spec), and a resume over a cached prefix then seeds an
+            # out-of-range block_table column, so the fused align pre-copy reads
+            # a garbage block id (illegal memory access on sm_121, silently
+            # wrong state where the read stays mapped) -- vllm#53142.
+            # ``_mamba_spec`` is populated by the first batch's preprocess;
+            # fresh requests seed from num_computed_tokens=0 either way, so the
+            # fallback is safe.
+            mamba_bs = (
+                self._mamba_spec.block_size
+                if self._mamba_spec is not None
+                else self.cache_config.block_size
+            )
             self._mamba_state_idx_gpu[req_index].fill_(
-                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
+                (new_req_data.num_computed_tokens - 1) // mamba_bs
             )
 
     def _get_mamba_group_info(
@@ -169,9 +183,9 @@ class MambaHybridModelState(DefaultModelState):
         ctx = self._mamba_ctx
         if not ctx.is_initialized:
             forward_context = self.vllm_config.compilation_config.static_forward_context
-            # block_tables are batch-order slices of the persistent
-            # input_block_tables (stable data_ptr), so the metadata is captured
-            # once here and reused across steps.
+            # ``block_tables`` are the SOURCE per-request-slot tables (stable
+            # data_ptr, req-indexed), so the metadata is captured once here and
+            # reused across steps; the copy kernels index rows by req_idx.
             ctx.initialize_from_forward_context(
                 kv_cache_config,
                 forward_context,

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -393,8 +393,9 @@ def postprocess_mamba_fused_kernel(
     # Output: num_accepted_tokens update (for src==dst case)
     num_accepted_tokens_out_ptr,
     # Optional: batch_idx -> req_idx mapping (V2 model runner / PP). The
-    # per-request decision arrays are in req-state-slot order; the block table
-    # is in batch order, so HAS_IDX_MAPPING splits the two indexings.
+    # per-request decision arrays AND the block tables are both in req-state-slot
+    # order, so rows are always indexed by req_idx; HAS_IDX_MAPPING only selects
+    # how a grid program (batch order) resolves its request slot.
     idx_mapping_ptr,
     # Runtime parameter (varies per batch - NOT constexpr to avoid recompilation)
     num_reqs,
@@ -478,7 +479,17 @@ def postprocess_mamba_fused_kernel(
     if src_block_idx == dest_block_idx and accept_token_bias == 0:
         return
 
-    bt_row_idx = batch_idx if HAS_IDX_MAPPING else req_idx
+    # The captured block tables are the SOURCE per-request-slot tables
+    # (persistent [max_num_reqs, max_blocks], mutated only by stream-ordered
+    # staged writes), so rows are always request-state slots -- index them by
+    # req_idx. Indexing by batch row read the CURRENT step's table at a stale
+    # batch mapping: on a non-last PP rank the deferred postprocess runs
+    # pp_size steps after its batch was gathered, so batch rows point at
+    # DIFFERENT requests and the state copy walks another request's
+    # freed/reallocated block ids. In the CSA unified layout every cache
+    # tensor aliases the same page, which is how foreign bytes landed in the
+    # PLE conv state (all-NaN logits -> constant-token loops; vllm#54173).
+    bt_row_idx = req_idx
     _copy_mamba_state_block(
         state_idx,
         bt_row_idx,
@@ -612,7 +623,8 @@ def precopy_mamba_align_fused_kernel(
     token_bias = tl.load(token_bias_ptr + req_idx)
     _copy_mamba_state_block(
         state_idx,
-        batch_idx,
+        # Source tables are req-indexed (see postprocess_mamba_fused_kernel).
+        req_idx,
         src_col,
         dst_col,
         token_bias,


### PR DESCRIPTION
PP + MTP + prefix caching corrupted mamba recurrent state (Qwen3.8-Flash-Next "duct" loops)

Fixes the silent state corruption that made **14–33 % of requests degenerate into a constant-token loop** whenever pipeline parallelism, MTP and prefix caching were combined — i.e. exactly the `MODE=pp` Qwen3.8-Flash-Next recipe this repo enabled in #47. Reproduced here at PP4 `13,13,13,9` + MTP4 + `--enable-prefix-caching --mamba-cache-mode align` + `FULL_AND_PIECEWISE`, `max_num_seqs 8`.

## Root cause

`MambaSpecDecodeGPUContext` captures the block tables' raw `data_ptr` **once** (idempotent `initialize_from_forward_context`), and the align copy kernels resolved the table row as `batch_idx if HAS_IDX_MAPPING else req_idx` — while the V2 runner bound that capture to the **per-step gathered** `input_block_tables`, which are batch-ordered and re-gathered every step.

Under async PP, a non-last rank runs postprocess `pp_size` steps late, so its batch mapping is stale: the kernel walks the *current* tables with a *stale* row mapping and copies GDN/PLE state through block ids belonging to (or reallocated to) **other requests**. The CSA unified layout aliases main KV, GDN conv/SSM and PLE conv inside one page, distinguished only by block-id ownership — so foreign bytes land in live state. Symptomatically that is all-NaN logits; the sampler turns an all-NaN row into token `1023` = `duct`, forever. On sm_121 the same misdirected read faults outright (vllm#54173 / #54199).

## Changes

| file | delta |
|---|---|
| `vllm/v1/worker/mamba_utils.py` | both copy kernels index the source tables by `req_idx`; comment corrected to state the real invariant |
| `vllm/v1/worker/gpu/model_runner.py` | bind the ctx to the **source per-request-slot** tables (`BlockTables.block_tables[i].gpu`), not the gathered views |
| `vllm/v1/worker/gpu/model_states/mamba_hybrid.py` | vllm#53142 (no upstream PR): align state-seed divisor must be the **mamba group's** block size, else a resume over a cached prefix seeds an out-of-range column and the pre-copy reads a garbage block id |
| `vllm/v1/core/single_type_kv_cache_manager.py` | vllm#48375 (open, unmerged): `MambaManager.find_longest_cache_hit` accepted `drop_eagle_block` and ignored it, so an MTP prefix-cache resume landed on a page whose recurrent-state snapshot was taken over draft tokens verification had rejected |
| `tests/kernels/mamba/test_precopy_mamba_align.py` | row-attribution tests: permuted `idx_mapping` **plus** per-slot-differing decisions. The existing suite only ever used `idx_mapping = arange(n)`, where batch row == request slot, so it structurally could not see this bug |

## Measured (4× CMP 170HX, sm_80)

| | before | after |
|---|---|---|
| 8-way soak, same harness | **16/48 loops (33 %)** | **0/56 loops** |
| mean acceptance length | 2.80 | 4.90–5.00 |
| 294 K / 509 K needle (`bench/qwen_longctx_needle.py`) | — | both exact |
| soak round time | 36.8 s | 31.6 s |

No perf cost by construction: same kernels, same launch counts, same copied bytes — only the row index changed.

## Do not "fix" this with a table pool

A rotating pool of gathered-table sets is not a substitute: with full CUDA graphs a captured graph bakes whichever slot's pointer was current at capture, and the other replays run against stale tables — the same corruption by another road. With this fix the ctx never touches gathered tables, so there is nothing to rotate.

## Upstream

Filed against `vllm-project/vllm` as **vllm#55506** (core fix + tests) and **vllm#55507** (`#53142` divisor). `#48375` is left to its own open PR; this branch carries the port so production is correct today.

Credit: root cause and fix direction identified first by @zebgop-ops — forensics at <https://github.com/zebgop-ops/qwen38-flashnext-pp> (`FINDINGS.md` addenda 11–19, patches `0010`/`0011`/`0012`; their ablation established that req-indexed source tables are necessary and sufficient).
