### PR TITLE
offloader: allocate pinned weight buffers at exact size (1.78x host RAM saved)

### DIFF
--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -189,9 +189,23 @@ def device_loading_context(module: torch.nn.Module, target_device: torch.device)
             if name in uva_offloaded_parameters and not getattr(
                 p, "_vllm_is_uva_offloaded", False
             ):
+                # The parameter is being re-offloaded after post-processing
+                # replaced it (Marlin repack).  Release the mapping the FIRST
+                # offload created, or both copies stay resident.
+                _stale_ptr = p.data.data_ptr()
                 cpu_data = p.data.to(device="cpu")
                 if use_pin_memory:
-                    cpu_data = cpu_data.pin_memory()
+                    # Exact-size pinning (see offloader.base.pin_exact). This is
+                    # the RE-offload after process_weights_after_loading swapped
+                    # the offloaded tensor for a new device tensor (e.g. a Marlin
+                    # repack), so without this the power-of-two rounding is paid
+                    # a SECOND time, on top of the initial offload.
+                    from vllm.model_executor.offloader.base import pin_exact
+
+                    cpu_data = pin_exact(cpu_data)
+                    from vllm.model_executor.offloader.base import release_pinned
+
+                    release_pinned(_stale_ptr)
                 p.data = get_accelerator_view_from_cpu_tensor(cpu_data)
                 p._vllm_is_uva_offloaded = True
 

--- a/vllm/model_executor/offloader/base.py
+++ b/vllm/model_executor/offloader/base.py
@@ -32,6 +32,99 @@ def should_pin_memory() -> bool:
     )
 
 
+# Anonymous mmaps backing exact-size pinned tensors, held for the process
+# lifetime.  See pin_exact() -- these back model weights, which live as long as
+# the model does; releasing them early un-maps memory CUDA still has registered.
+_PINNED_MAPPINGS: dict[int, object] = {}
+
+
+def pin_exact(t: "torch.Tensor") -> "torch.Tensor":
+    """Return a page-locked copy of ``t`` occupying EXACTLY its own size.
+
+    ``Tensor.pin_memory()`` allocates through torch's ``CachingHostAllocator``,
+    which rounds every block up to the next power of two.  For the large,
+    awkwardly-sized tensors weight offloading deals with that is not a rounding
+    error but a multiplier: a 2.250 GiB expert block costs 4.008 GiB of pinned
+    host memory (measured 1.78x, torch 2.13.0+cu130).  Offloading a MoE's experts
+    therefore needs ~1.78x the host RAM the weights occupy and the process is
+    OOM-killed during construction, long before ``cpu_offload_gb`` is reached.
+    (For reference, llama.cpp pins the same class of weights at ~1.0x.)
+
+    An anonymous mmap is page-aligned by construction and exactly sized;
+    registering it with ``cudaHostRegister`` yields page-locked memory with no
+    bucketing.  Falls back to ``pin_memory()`` if registration is unavailable.
+    """
+    import mmap
+
+    import torch
+
+    nbytes = t.numel() * t.element_size()
+    if nbytes == 0 or not t.is_contiguous():
+        # Non-contiguous inputs would need the strided layout rebuilt over the
+        # mapping; not worth it -- these are small next to the expert blocks.
+        return t.pin_memory()
+
+    buf = None
+    try:
+        buf = mmap.mmap(-1, nbytes)
+        # Build the tensor at its final dtype/shape directly -- no uint8->dtype
+        # ->shape view chain, whose intermediate bases confuse downstream code
+        # that inspects storage_offset()/is_contiguous().
+        out = torch.frombuffer(buf, dtype=t.dtype, count=t.numel()).view(t.shape)
+        # Register the WHOLE mapping (mmap rounds up to a page), not just nbytes.
+        rc = torch.cuda.cudart().cudaHostRegister(out.data_ptr(), len(buf), 0)
+        if int(rc) != 0:
+            raise RuntimeError(f"cudaHostRegister returned {rc}")
+        out.copy_(t)
+        # ⚠️ LIFETIME: the mapping must outlive every view of it.  Attaching the
+        # mmap to the returned tensor is NOT enough -- callers reassign
+        # ``param.data`` and drop this object, the mmap is munmapped while still
+        # CUDA-registered, and the next copy fails with cudaErrorInvalidValue.
+        # Offloaded weights live for the life of the model, so hold a process-
+        # level reference keyed by pointer.
+        _PINNED_MAPPINGS[out.data_ptr()] = buf
+        return out
+    except Exception as e:  # pragma: no cover - platform fallback
+        if buf is not None:
+            try:
+                buf.close()
+            except Exception:
+                pass
+        logger.warning_once(
+            "pin_exact() unavailable (%s); falling back to Tensor.pin_memory(), "
+            "which rounds allocations up to the next power of two.", e
+        )
+        return t.pin_memory()
+
+
+def release_pinned(ptr: int) -> bool:
+    """Unregister and unmap an exact-size pinned buffer created by pin_exact().
+
+    ⚠️ Callers that REPLACE an offloaded parameter must call this with the old
+    ``data_ptr()``.  ``process_weights_after_loading`` repacks expert weights
+    (e.g. for Marlin), so the same logical parameter is offloaded twice; without
+    releasing the first mapping both copies are held and the process needs
+    roughly double the host RAM.  ``Tensor.pin_memory()`` gets this for free --
+    its caching allocator recycles the block when the old tensor dies -- so the
+    exact-size path has to do the recycling explicitly.
+    """
+    import torch
+
+    buf = _PINNED_MAPPINGS.pop(ptr, None)
+    if buf is None:
+        return False
+    try:
+        torch.cuda.cudart().cudaHostUnregister(ptr)
+    except Exception:  # pragma: no cover
+        pass
+    try:
+        buf.close()
+    except Exception:  # pragma: no cover
+        pass
+    return True
+
+
+
 """
 class relation:
 

--- a/vllm/model_executor/offloader/prefetch.py
+++ b/vllm/model_executor/offloader/prefetch.py
@@ -673,15 +673,20 @@ class _CpuParamOffloader(_BaseParamOffloader):
 
         if param.data.device.type == "cpu":
             if should_pin_memory() and not param.data.is_pinned():
-                pinned = torch.empty_strided(
+                # Allocate unpinned, then page-lock at exactly this size.
+                # pin_memory=True here rounds to the next power of two.
+                from vllm.model_executor.offloader.base import pin_exact
+
+                staging = torch.empty_strided(
                     size=param.data.size(),
                     stride=param.data.stride(),
                     dtype=param.data.dtype,
                     layout=param.data.layout,
                     device="cpu",
-                    pin_memory=True,
+                    pin_memory=False,
                 )
-                pinned.copy_(param.data)
+                staging.copy_(param.data)
+                pinned = pin_exact(staging)
                 self._cpu_storage = pinned
             else:
                 self._cpu_storage = param.data

--- a/vllm/model_executor/offloader/uva.py
+++ b/vllm/model_executor/offloader/uva.py
@@ -10,7 +10,7 @@ from torch.func import functional_call
 
 import vllm.envs as envs
 from vllm.logger import init_logger
-from vllm.model_executor.offloader.base import BaseOffloader, should_pin_memory
+from vllm.model_executor.offloader.base import BaseOffloader, pin_exact, should_pin_memory
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.platform_utils import is_uva_available
 from vllm.utils.torch_utils import get_accelerator_view_from_cpu_tensor
@@ -110,7 +110,11 @@ class UVAOffloader(BaseOffloader):
 
             cpu_data = p.data.to(device="cpu")
             if self.pin_memory:
-                cpu_data = cpu_data.pin_memory()
+                # Exact-size page-locked allocation. Tensor.pin_memory() rounds to
+                # the next power of two (measured 1.78x on large expert blocks),
+                # which multiplies the host RAM an offloaded MoE needs and gets the
+                # worker OOM-killed during construction.
+                cpu_data = pin_exact(cpu_data)
 
             if not self.uva_offloading:
                 p.data = cpu_data


### PR DESCRIPTION
## Problem

`Tensor.pin_memory()` allocates through torch's `CachingHostAllocator`, which rounds every
block up to the next power of two. For the large, awkwardly-sized tensors weight offloading
deals with, that is not a rounding error — it is a multiplier.

Measured on torch 2.13.0+cu130 (`RssShmem` delta per allocation):

| requested | `pin_memory()` | ratio |
|---:|---:|---:|
| 2.250 GiB | 4.008 GiB | **1.781×** |
| 1.125 GiB | 2.000 GiB | 1.778× |
| 0.563 GiB | 1.000 GiB | 1.778× |

So offloading a MoE's experts needs ~1.78× the host RAM the weights actually occupy, and the
worker is OOM-killed during construction long before `cpu_offload_gb` is reached.

Concretely, GLM-5.3-Flash AWQ W4A16 with `--cpu-offload-params experts`: the routed experts
sum to **146.7 GiB**, but the offloader needs **~260 GiB** of pinned host memory to hold them.
On a 196 GiB host the process dies with `Out of memory: Killed process … (VLLM::EngineCor)`
before the offload total is ever logged.

For reference, `llama.cpp` pins the same class of weights at ≈1.0× (`Shmem` 140 GiB for a
147 GB GGUF, 108 GiB for a 113 GB one, on two different hosts) — this is specific to torch's
caching allocator, not to pinned memory or to any particular hardware.

## Fix

`pin_exact()` allocates an anonymous `mmap` (page-aligned by construction, exact size) and
page-locks it with `cudaHostRegister`, bypassing the caching allocator. It falls back to
`Tensor.pin_memory()` if registration is unavailable, and for non-contiguous inputs.

Applied at the three sites that pin offloaded weights:

- `offloader/uva.py` — the initial offload
- `offloader/prefetch.py` — the staging buffer (`pin_memory=True` → unpinned + `pin_exact`)
- `model_loader/utils.py` — the **re-offload** after `process_weights_after_loading`

`release_pinned()` is the necessary companion: `pin_memory()` gets recycling for free (its
allocator reuses the block when the old tensor dies), so the exact-size path has to recycle
explicitly. Without it, `process_weights_after_loading` repacking experts (e.g. for Marlin)
leaves both the pre- and post-repack mappings resident and the footprint grows past the
unpatched figure.

## Result

Same model, same flags:

| | pinned host memory for experts |
|---|---|
| before | ~260 GiB (OOM-killed at 196 GiB, no total logged) |
| after | **`Total CPU offloaded parameters: 146.73`** |

Reproduced across four `--load-format dummy` runs, including TP=2 where it splits exactly
(73.55 GiB per rank).

**Since confirmed on real weights** (`load_format=auto`, GLM-5.3-Flash AWQ W4A16, TP=2, two
independent runs differing in context length, MTP and `gpu-memory-utilization`): both ranks log
`Total CPU offloaded parameters: 73.55` — byte-identical to the dummy figure — with **zero**
`falling back to Tensor.pin_memory` warnings, and all 13 (resp. 9) checkpoint shards read in
~272 s. So the exact-size path holds when real tensors are loaded, repacked and re-offloaded,
not just when correctly-shaped random ones are allocated.

## Verification

Unit tests against the helper (13 assertions, all passing): exact sizing at 1.000× for
float16 / int32 / uint8 at multi-GiB sizes; `is_pinned()` True after registration and False
after unregistration; values copied correctly; `is_contiguous()`; `storage_offset() == 0`;
`transpose().contiguous()` then H2D; and — the case that matters — a **real H2D copy after
every Python reference to the returned tensor is dropped**, which is what `param.data = …`
does and what a naive implementation gets wrong (the mmap is freed while CUDA still holds the
registration, surfacing later as `cudaErrorInvalidValue`).

## Not fixed by this PR

On a 196 GiB host, GLM-5.3-Flash AWQ W4A16 still does not complete loading. With the experts
down to their true 146.7 GiB, host RAM continues climbing **after** the offload total is logged,
with the pinned-mapping registry provably flat throughout — so the residual is separate from this
change. It is reached inside `process_weights_after_loading`, immediately after
`int_wna16.py` logs `Using MarlinExperts`, and it ends in a kernel OOM kill rather than a Python
exception:

```
Out of memory: Killed process (VLLM::Worker_TP)
  total-vm:231368732kB  anon-rss:1079992kB  shmem-rss:94992888kB
```

Two runs, ~71 s and ~75 s after the `MarlinExperts` line respectively:

| | run 1 | run 2 |
|---|---|---|
| config | MTP head present, 4096 ctx, util 0.85 | MTP removed, 204800 ctx, util 0.90 |
| `Total CPU offloaded parameters` | 73.55 / rank | 73.55 / rank (identical) |
| `shmem-rss` at kill | 90.59 GiB / rank | 86.09 GiB / rank |
| outcome | OOM in Marlin repack | OOM in Marlin repack |

Two observations that may help whoever picks this up:

1. **`shmem-rss` at kill exceeds the reported offload total by 12.5-17 GiB per rank** (86-91 GiB
   resident vs 73.55 GiB offloaded). Two ranks put 172-181 GiB of page-locked memory resident on a
   196 GiB host before the repack transients are counted at all. I have not attributed that
   difference and am not claiming a cause.
2. Because the memory is page-locked it **cannot be swapped**, so adding swap does not help.

I have not diagnosed the repack itself; flagging it since anyone offloading a model this size will
meet it. This PR removes 113 GiB of pure waste and brings the model materially closer to loading on
this host; it should load outright with more RAM.

## Notes for review

- `release_pinned()` puts a real burden on callers — any site that replaces an offloaded
  parameter must release the old pointer. Tying the mapping's lifetime to the tensor's
  storage would be cleaner, but I could not find a way to do that from Python that survives
  `param.data = …` dropping the wrapper. Happy to rework if you know one.
- The registry is keyed by `data_ptr()`. That is safe here because entries are removed before
  the memory can be reused, but it is worth a second opinion.
- Tested on 2× RTX 3090 (sm_86), CUDA 13, `lazymio/vllm-backport:latest-sm86`.

Note on prior reports: #34 and #15 are **not** this problem — both are GPU-side
(`CUDACachingAllocator` / `torch.OutOfMemoryError`), whereas this is host RAM. #15 is
nonetheless the useful datapoint: it runs `cpu-offload-gb 2.5`, i.e. offload as a few-GB
top-up. That is likely why the 1.78x pinning multiplier has not surfaced before — it only
becomes load-bearing when offload holds most of the model rather than the tail of it.
